### PR TITLE
Auto-fund: send ETH, it becomes tradeable USDC on HyperLiquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ gclaw dashboard     # watch its living DNA page
 gclaw talk Gclaw    # say hello (run inside Claude Code to converse)
 ```
 
-That's it. `install.sh` makes you a fresh managed-custody wallet and prints the two
-addresses to fund:
+That's it. `install.sh` makes you a fresh managed-custody wallet and prints the addresses to fund:
 
-- **Trading capital** — USDC on the HyperLiquid account (this is what it trades).
+- **Trading capital** — send USDC **or just ETH** on Arbitrum. If you send ETH, `gclaw autofund`
+  (and every heartbeat) automatically swaps the surplus to USDC and deposits it to HyperLiquid,
+  keeping a gas reserve. No manual bridging or swapping.
 - **Identity gas** — ~0.001 ETH on Base (to mint its onchain identity; optional to start).
 
-`gclaw fund` polls until your money lands and says **✓ Ready to live**.
+`gclaw fund` counts your USDC *and* any convertible ETH, and says **✓ Ready to live** when set.
 
 ## The one command for everything — `gclaw`
 

--- a/bin/gclaw
+++ b/bin/gclaw
@@ -4,6 +4,7 @@
 #   gclaw doctor      check everything is set up
 #   gclaw wallet      create your wallet + show what to fund
 #   gclaw fund        check whether your money has landed
+#   gclaw autofund    convert ETH you sent (Arbitrum) → USDC → HyperLiquid
 #   gclaw start       bring your creature to life (birth + hourly heartbeat)
 #   gclaw status      how it's doing right now
 #   gclaw dashboard   open its living DNA page
@@ -43,6 +44,11 @@ cmd_fund() {
   "$NODE" "$SKILL_DIR/scripts/fund_status.js" || true
 }
 
+cmd_autofund() {
+  b "Auto-fund: converting any ETH on Arbitrum → USDC → HyperLiquid"
+  "$NODE" "$SKILL_DIR/scripts/autofund.js" "${1:-run}" || true
+}
+
 birth() {
   if [ ! -f "$GCLAW_HOME/metabolism.json" ]; then
     "$PY" "$SKILL_DIR/scripts/metabolism.py" init --seed 1000 >/dev/null
@@ -69,6 +75,8 @@ install_cron() {
 cmd_start() {
   b "Bringing your creature to life"
   birth
+  # If the player sent ETH, convert it to tradeable USDC before going live.
+  "$NODE" "$SKILL_DIR/scripts/autofund.js" run >/dev/null 2>&1 && ok "auto-funded (converted any sent ETH → USDC)" || true
   "$PY" "$SKILL_DIR/scripts/dashboard.py" render >/dev/null && ok "DNA dashboard rendered"
   install_cron
   echo; "$PY" "$SKILL_DIR/scripts/metabolism.py" status
@@ -98,10 +106,11 @@ case "${1:-help}" in
   install) cmd_install ;;
   wallet) shift; cmd_wallet "$@" ;;
   fund) cmd_fund ;;
+  autofund) shift; cmd_autofund "$@" ;;
   start) cmd_start ;;
   status) cmd_status ;;
   dashboard|dash) cmd_dashboard ;;
   talk) shift; cmd_talk "$@" ;;
   beat|heartbeat) cmd_beat ;;
-  *) sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' ;;
+  *) sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' ;;
 esac

--- a/scripts/autofund.js
+++ b/scripts/autofund.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Gclaw auto-fund — turn "just send ETH" into tradeable USDC on HyperLiquid.
+ *
+ * HL only accepts USDC deposits (min $10) and deposits cost gas. So a player can
+ * simply send ETH to their managed Arbitrum wallet, and this swaps the surplus
+ * (keeping a gas reserve) into USDC and deposits it to HL — fully automated.
+ *
+ *   node autofund.js plan      # show ETH found + what it would convert (no spend)
+ *   node autofund.js run       # swap ETH->USDC on Arbitrum, deposit to HL
+ *
+ * Env: GDEX_SKILL_DIR, GCLAW_WALLET, ARB_RPC, GDEX_API_KEY.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const GDEX_DIR = process.env.GDEX_SKILL_DIR || path.join(os.homedir(), 'gdex-skill');
+const { ethers } = require(path.join(GDEX_DIR, 'node_modules', 'ethers'));
+const SDK = require(path.join(GDEX_DIR, 'dist'));
+
+const WALLET_PATH = process.env.GCLAW_WALLET || [path.join(os.homedir(), '.gclaw', 'wallet.json'), path.join(os.homedir(), 'gdex-test-wallet.json')].find((p) => fs.existsSync(p)) || path.join(os.homedir(), 'gdex-test-wallet.json');
+const ARB_RPC = process.env.ARB_RPC || 'https://arb1.arbitrum.io/rpc';
+const ARB_CHAIN = 42161;
+const ARB_USDC = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+const GAS_RESERVE_ETH = 0.0003; // keep enough Arbitrum ETH for the swap + deposit tx
+const MIN_DEPOSIT_USDC = 10; // HyperLiquid minimum
+const SLIPPAGE = 2;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function loadWallet() {
+  const w = JSON.parse(fs.readFileSync(WALLET_PATH, 'utf8'));
+  const managed = w.managed?.['Arbitrum (HyperLiquid)']?.address;
+  if (!managed) throw new Error('wallet missing managed Arbitrum address');
+  return { control: w.control.address, pk: w.control.privateKey, managed };
+}
+
+async function arbProvider() {
+  return new ethers.JsonRpcProvider(ARB_RPC);
+}
+
+async function usdcBalance(provider, addr) {
+  const erc20 = new ethers.Contract(ARB_USDC, ['function balanceOf(address) view returns (uint256)'], provider);
+  return Number(ethers.formatUnits(await erc20.balanceOf(addr), 6));
+}
+
+async function signIn(skill, wallet) {
+  const apiKey = process.env.GDEX_API_KEY || SDK.GDEX_API_KEY_PRIMARY;
+  const kp = SDK.generateGdexSessionKeyPair();
+  const nonce = SDK.generateGdexNonce().toString();
+  const sig = (await new ethers.Wallet(wallet.pk).signMessage(SDK.buildGdexSignInMessage(wallet.control, nonce, kp.sessionKey))).replace(/^0x/, '');
+  const payload = SDK.buildGdexSignInComputedData({ apiKey, userId: wallet.control, sessionKey: kp.sessionKey, nonce, signature: sig });
+  await skill.signInWithComputedData({ computedData: payload.computedData, chainId: ARB_CHAIN });
+  return { apiKey, walletAddress: wallet.control, sessionPrivateKey: kp.sessionPrivateKey };
+}
+
+async function main() {
+  const mode = process.argv[2] || 'plan';
+  const wallet = loadWallet();
+  const provider = await arbProvider();
+  const ethBal = Number(ethers.formatEther(await provider.getBalance(wallet.managed)));
+  const swapEth = Math.max(0, ethBal - GAS_RESERVE_ETH);
+  const summary = { ok: true, mode, arbitrumEth: ethBal, gasReserve: GAS_RESERVE_ETH, swapEth: Number(swapEth.toFixed(6)) };
+
+  if (swapEth <= 0) {
+    summary.action = 'nothing to convert (ETH at or below gas reserve)';
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+  if (mode === 'plan') {
+    summary.action = `would swap ${swapEth.toFixed(6)} ETH → USDC on Arbitrum, then deposit to HL (if ≥ $${MIN_DEPOSIT_USDC})`;
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const skill = new SDK.GdexSkill({ timeout: 60000, maxRetries: 1 });
+  skill.loginWithApiKey(process.env.GDEX_API_KEY || SDK.GDEX_API_KEY_PRIMARY);
+  const creds = await signIn(skill, wallet);
+
+  const before = await usdcBalance(provider, wallet.managed);
+  const swap = await skill.buyToken({ chain: ARB_CHAIN, tokenAddress: ARB_USDC, amount: String(swapEth), slippage: SLIPPAGE, ...creds });
+  if (swap && swap.isSuccess === false) throw new Error(`swap rejected: ${JSON.stringify(swap)}`);
+  summary.swap = 'submitted';
+
+  let after = before;
+  for (let i = 0; i < 12 && after <= before + 0.01; i += 1) {
+    await sleep(5000);
+    after = await usdcBalance(provider, wallet.managed);
+  }
+  const gained = Number((after - before).toFixed(6));
+  summary.usdcReceived = gained;
+
+  if (after >= MIN_DEPOSIT_USDC) {
+    const dep = await skill.perpDeposit({ amount: String(Math.floor(after)), tokenAddress: ARB_USDC, chainId: ARB_CHAIN, ...creds });
+    if (dep && dep.isSuccess === false) throw new Error(`deposit rejected: ${JSON.stringify(dep)}`);
+    summary.deposited = `${Math.floor(after)} USDC → HyperLiquid`;
+    summary.action = 'swapped + deposited — ready to trade';
+  } else {
+    summary.action = `swapped to $${after.toFixed(2)} USDC; holding on Arbitrum (below $${MIN_DEPOSIT_USDC} HL min — add more ETH)`;
+  }
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.log(JSON.stringify({ ok: false, error: e?.responseBody ? JSON.stringify(e.responseBody) : e.message || String(e) }));
+    process.exit(1);
+  });

--- a/scripts/fund_status.js
+++ b/scripts/fund_status.js
@@ -63,29 +63,46 @@ async function main() {
   const tradingUsdc = perpUsd + spotUsd;
 
   let baseEth = 0;
+  let arbEth = 0;
   try {
-    const provider = new ethers.JsonRpcProvider(process.env.BASE_RPC || 'https://mainnet.base.org');
-    baseEth = Number(ethers.formatEther(await provider.getBalance(control)));
+    const baseP = new ethers.JsonRpcProvider(process.env.BASE_RPC || 'https://mainnet.base.org');
+    baseEth = Number(ethers.formatEther(await baseP.getBalance(control)));
+  } catch {
+    /* leave 0 */
+  }
+  try {
+    // ETH sent to the managed Arbitrum wallet can be auto-swapped to USDC + deposited.
+    const arbP = new ethers.JsonRpcProvider(process.env.ARB_RPC || 'https://arb1.arbitrum.io/rpc');
+    arbEth = Number(ethers.formatEther(await arbP.getBalance(hl)));
   } catch {
     /* leave 0 */
   }
 
+  const convertibleEth = Math.max(0, arbEth - 0.0003); // minus a gas reserve
   const canTrade = tradingUsdc >= MIN_TRADING_USDC;
   const canMint = baseEth >= MIN_BASE_ETH;
   const verdict = {
     ok: true,
     ready: canTrade,
     tradingUsdc: Math.round(tradingUsdc * 100) / 100,
+    arbitrumEth: arbEth,
+    convertibleEth: Number(convertibleEth.toFixed(6)),
     baseEthGas: baseEth,
     canTrade,
     canMintIdentity: canMint,
     fund: {
-      tradingCapital: canTrade ? '✓ funded' : `→ send USDC on Arbitrum to ${hl}`,
+      tradingCapital: canTrade
+        ? '✓ funded'
+        : convertibleEth > 0
+          ? `≈ ${convertibleEth.toFixed(5)} ETH on Arbitrum to convert — run: gclaw autofund`
+          : `→ send USDC (or ETH) on Arbitrum to ${hl}`,
       identityGas: canMint ? '✓ funded' : `→ send ~0.001 ETH on Base to ${control}`,
     },
     message: canTrade
       ? '✓ Ready to live — run: gclaw start'
-      : 'Waiting on trading capital (USDC on the HyperLiquid account).',
+      : convertibleEth > 0
+        ? 'You sent ETH — run `gclaw autofund` to convert it to USDC and deposit to HL.'
+        : 'Send USDC or ETH to the Arbitrum address, then `gclaw autofund`.',
   };
   console.log(JSON.stringify(verdict, null, 2));
 }

--- a/scripts/new_wallet.js
+++ b/scripts/new_wallet.js
@@ -65,10 +65,12 @@ async function main() {
   console.log(`   control / identity: ${w.address}`);
   console.log('\n💰 Fund these to come alive:');
   const hl = managed['Arbitrum (HyperLiquid)'];
-  const base = managed['Base'];
-  if (hl?.address) console.log(`   • Trading capital → send USDC on Arbitrum to:\n       ${hl.address}`);
-  if (base?.address) console.log(`   • Gas for onchain identity → send ~0.001 ETH on Base to:\n       ${w.address}`);
-  console.log('\n   Then run:  gclaw fund    (checks your balances)  ·  gclaw start   (go live)');
+  if (hl?.address) {
+    console.log(`   • Trading capital → send USDC **or just ETH** on Arbitrum to:\n       ${hl.address}`);
+    console.log('       (ETH is auto-swapped to USDC + deposited — run: gclaw autofund)');
+  }
+  console.log(`   • Gas for onchain identity → send ~0.001 ETH on Base to:\n       ${w.address}`);
+  console.log('\n   Then run:  gclaw fund   ·   gclaw autofund   ·   gclaw start');
 }
 
 main()

--- a/templates/heartbeat.sh
+++ b/templates/heartbeat.sh
@@ -20,6 +20,10 @@ exec 9>"$LOCK"; flock -n 9 || { echo "$(ts) still running, skipped" >>"$LOG"; ex
 echo "===== $(ts) heartbeat start =====" >>"$LOG"
 cd "$HOME"
 
+# Auto-fund: convert any ETH a player sent to Arbitrum into USDC + deposit to HL.
+[[ -f "$SKILL_DIR/scripts/autofund.js" ]] &&
+  echo "$(ts) autofund: $(node "$SKILL_DIR/scripts/autofund.js" run 2>&1)" >>"$LOG" || true
+
 # Deterministic: book realized PnL from any closes before the agent decides.
 [[ -f "$SKILL_DIR/scripts/autosettle.js" ]] &&
   echo "$(ts) autosettle: $(node "$SKILL_DIR/scripts/autosettle.js" run 2>&1)" >>"$LOG" || true


### PR DESCRIPTION
Players can fund with plain ETH on Arbitrum instead of USDC. `autofund.js` swaps the surplus (keeping a gas reserve) to USDC and deposits it to HyperLiquid. `gclaw fund` now counts convertible Arbitrum ETH; `gclaw autofund` runs it on demand; the hourly heartbeat and `gclaw start` auto-convert any sent ETH. Verified plan + the funding counter live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)