### PR TITLE
Perp leverage + full-universe trading

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -81,7 +81,9 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
    `get_hl_top_traders_by_pnl`. For events: `hl_outcomes`.
 6. **Decide & act (MCP).** At most one or two conservative moves consistent with the strategy and `mode`.
    - Open perp: `mcp__gdex__open_perp_position` with `{apiKey, walletAddress: <control>, sessionPrivateKey,
-     coin, isLong, price: <mark>, size, tpPrice, slPrice}`. A stop is mandatory; clear the $11 min. Explain the thesis first.
+     coin, isLong, price: <mark>, size, tpPrice, slPrice, leverage}`. **Pass `leverage` in the order** (≤3x per
+     strategy; HL defaults to 20x if omitted) — there is no separate set_leverage call. A stop is mandatory;
+     clear the $11 min. Explain the thesis first.
    - Close perp: `mcp__gdex__close_perp_position {apiKey, walletAddress, sessionPrivateKey, coin}`.
    - Outcome bet (defined-risk events): `node scripts/hl_outcomes.js list` then `order --outcome <id> --coin <side> --buy --price <p> --size <n>`
      (fund via `mcp__gdex__hl_swap_collateral` first). See `references/trading.md` §B. Prefer these in SURVIVE mode.

--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -4,16 +4,18 @@
 Compound GMAC through disciplined HyperLiquid trading. Replace the seeded 1000
 GMAC with real realized profit, then grow it without ever risking extinction.
 
-## Venues (and nothing else)
-1. **HyperLiquid perpetuals** — the core engine. Majors only to start: BTC, ETH, SOL.
+## Venues
+1. **HyperLiquid perpetuals (USDC, default dex)** — the core engine. Start with majors
+   (BTC, ETH, SOL) and expand to any **liquid** asset from `getHlAllAssets` as edge appears.
 2. **HIP-3 outcome / event markets** — the defined-risk satellite for asymmetric, near-dated bets.
+3. **Builder/HIP-3 perps** (stocks `xyz:NVDA`, oil `flx:OIL`, etc.) — available, but trade only
+   where the account holds that dex's collateral. Lead with the USDC default-dex markets.
 
-No Solana memecoins. No unlisted low-liquidity tokens. The venues above have deep
-books and bounded, legible risk.
+No memecoins. No unlisted low-liquidity tokens. Liquidity and a legible thesis gate every name.
 
 ## Risk controls (hard limits)
 - **Max risk per trade:** 5% of current GMAC balance. In SURVIVE mode, 2%.
-- **Max leverage:** 3x on perps. Never higher. Lower is better.
+- **Max leverage:** 3x. Set it explicitly in the order (`leverage`), never rely on HL's 20x default.
 - **Always** set TP and SL when opening a perp. No naked positions.
 - **One or two open theses at a time.** No scattering risk across many names.
 - Keep dry powder: never deploy the whole treasury; the survival buffer is sacred.

--- a/references/mcp-trading.md
+++ b/references/mcp-trading.md
@@ -27,11 +27,14 @@ The session is now live. Keep `sessionPrivateKey` and `apiKey` for the trade cal
 
 ## Writes (use control address as walletAddress + the session)
 
-- **Open:** `mcp__gdex__open_perp_position`
-  `{ apiKey, walletAddress: <control/userId>, sessionPrivateKey, coin, isLong, price: <mark>, size, tpPrice, slPrice }`.
-  `size` is in contracts (coin units). Enforce HL's **$11 min notional** and **always** pass tp/sl.
-- **Leverage (optional):** `mcp__gdex__set_leverage` `{ apiKey, walletAddress, sessionPrivateKey, coin, leverage, isCross: true }`.
-  HL defaults to ~20x cross; risk is bounded by the stop, so this is rarely needed.
+- **Open (set leverage in the order):** `mcp__gdex__open_perp_position`
+  `{ apiKey, walletAddress: <control/userId>, sessionPrivateKey, coin, isLong, price: <mark>, size, tpPrice, slPrice, leverage }`.
+  Pass **`leverage`** in the open (1–50; keep to the strategy cap, **≤3x**). HL defaults to 20x if
+  you omit it. `size` is in contracts (coin units). Enforce HL's **$11 min notional** and always pass tp/sl.
+  - There is **no** working `set_leverage` / `update_leverage` call — that endpoint is 404. Leverage is
+    a field on the order itself.
+  - For builder/HIP-3 markets (stocks: `xyz:NVDA`, oil: `flx:OIL`), pass the coin with the **lowercase
+    dex prefix**, and use the per-asset mark from `get_hl_meta_and_asset_ctxs`/`getHlAllAssets` (not `get_mark_price`).
 - **Close:** `mcp__gdex__close_perp_position` `{ apiKey, walletAddress, sessionPrivateKey, coin }` —
   realizes PnL; read it back from `get_hl_clearinghouse_state` and `settle` into metabolism.
 

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -33,13 +33,32 @@ const SDK = require(path.join(GDEX_DIR, 'dist'));
 
 const HL_CHAIN_ID = 42161; // sign in on Arbitrum for HyperLiquid
 const MIN_NOTIONAL = 11; // HyperLiquid minimum order value (USD)
+const DEFAULT_LEVERAGE = 3; // strategy cap; HL defaults to 20x cross if we don't set it
 const SZ_DECIMALS = { BTC: 5, ETH: 4, SOL: 2 }; // fallback size precision if meta is unavailable
+
+// Builder/HIP-3 coins are `dex:ASSET` with a LOWERCASE dex prefix (xyz:NVDA); plain coins uppercase.
+function normalizeCoin(coin) {
+  const i = coin.indexOf(':');
+  return i === -1 ? coin.toUpperCase() : coin.slice(0, i).toLowerCase() + ':' + coin.slice(i + 1).toUpperCase();
+}
+
+async function findAsset(skill, coin) {
+  const a = await skill.getHlAllAssets();
+  const arr = Array.isArray(a) ? a : a.data || a.assets || a.universe || [];
+  return arr.find((x) => String(x.coin).toLowerCase() === coin.toLowerCase() || x.baseCoin === coin);
+}
+
+// getHlMarkPrice only covers the default dex; builder markets need getHlAllAssets.markPx.
+async function markPriceFor(skill, coin) {
+  const px = await skill.getHlMarkPrice(coin).catch(() => 0);
+  if (px > 0) return px;
+  const asset = await findAsset(skill, coin).catch(() => null);
+  return Number(asset?.markPx) || 0;
+}
 
 async function szDecimalsFor(skill, coin) {
   try {
-    const a = await skill.getHlAllAssets();
-    const arr = Array.isArray(a) ? a : a.data || a.assets || a.universe || [];
-    const m = arr.find((x) => x.coin === coin || x.baseCoin === coin);
+    const m = await findAsset(skill, coin);
     if (m && Number.isInteger(m.szDecimals)) return m.szDecimals;
   } catch {
     /* fall back to the static map below */
@@ -128,15 +147,18 @@ async function cmdStatus(wallet) {
 }
 
 async function cmdOpen(wallet, args) {
-  const coin = (args.coin || 'ETH').toUpperCase();
+  const coin = normalizeCoin(args.coin || 'ETH');
   const isLong = (args.side || 'long').toLowerCase() !== 'short';
   const notionalTarget = Math.max(MIN_NOTIONAL + 1, Number(args.notional || 12));
   const slPct = Number(args['sl-pct'] || 2);
   const tpPct = Number(args['tp-pct'] || 3);
   if (!args['sl-pct'] && slPct <= 0) die('a stop-loss is required (--sl-pct)');
 
+  // Leverage is a real, settable order field now (sent top-level by the SDK).
+  const leverage = Math.max(1, Math.min(50, Math.round(Number(args.leverage || DEFAULT_LEVERAGE))));
+
   const { skill, creds } = await signedSkill(wallet);
-  const px = await skill.getHlMarkPrice(coin);
+  const px = await markPriceFor(skill, coin);
   const dp = await szDecimalsFor(skill, coin);
   const size = Math.max(0, Number((notionalTarget / px).toFixed(dp)));
   const notional = px * size;
@@ -153,20 +175,23 @@ async function cmdOpen(wallet, args) {
     isMarket: true,
     tpPrice: String(tp),
     slPrice: String(sl),
+    leverage,
     ...creds,
   });
   if (res && res.isSuccess === false) die(`open rejected: ${JSON.stringify(res)}`);
-  return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', mark: px, size, notional: Number(notional.toFixed(2)), sl, tp };
+  return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', leverage, mark: px, size, notional: Number(notional.toFixed(2)), sl, tp };
 }
 
 async function cmdClose(wallet, args) {
-  const coin = (args.coin || 'ETH').toUpperCase();
+  const coin = normalizeCoin(args.coin || 'ETH');
   const { skill, creds } = await signedSkill(wallet);
   const state = await skill.getHlAccountState(wallet.managed);
-  const pos = (state.positions || []).find((p) => (p.coin || p.position?.coin) === coin);
+  const pos = (state.positions || []).find(
+    (p) => String(p.coin || p.position?.coin).toLowerCase() === coin.toLowerCase(),
+  );
   const szi = pos ? Number(pos.size ?? pos.szi ?? pos.position?.szi) : 0;
   if (!szi) return { ok: true, action: 'close', coin, note: 'no open position' };
-  const px = await skill.getHlMarkPrice(coin);
+  const px = await markPriceFor(skill, coin);
   const res = await skill.hlCreateOrder({
     coin,
     isLong: szi < 0, // opposite side to flatten


### PR DESCRIPTION
Now that the GDEX SDK forwards leverage (top-level) and handles builder-dex coins, gclaw sets leverage explicitly in the order (≤3x), normalizes builder coins (xyz:NVDA), resolves builder marks from getHlAllAssets, and expands the strategy from majors-only to the full liquid USDC universe. Verified live: opened SOL at 3x via the CLI and closed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)