### PR TITLE
Read builder-dex positions across all dexes

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -8,14 +8,18 @@ GMAC with real realized profit, then grow it without ever risking extinction.
 1. **HyperLiquid perpetuals (USDC, default dex)** — the core engine. Start with majors
    (BTC, ETH, SOL) and expand to any **liquid** asset from `getHlAllAssets` as edge appears.
 2. **HIP-3 outcome / event markets** — the defined-risk satellite for asymmetric, near-dated bets.
-3. **Builder/HIP-3 perps** (stocks `xyz:NVDA`, oil `flx:OIL`, etc.) — available, but trade only
-   where the account holds that dex's collateral. Lead with the USDC default-dex markets.
+3. **Builder/HIP-3 perps** (stocks `xyz:NVDA`/`xyz:TSLA`/`xyz:SPCX`, oil, etc.) — the `xyz` dex is
+   **USDC-collateralized, 24h** (no collateral swap needed) and is verified working: opens fill and
+   honor the leverage passed (3x isolated, live-confirmed). Pass the coin lowercase-prefixed and read
+   the position with `dex: "xyz"`. Lead with default-dex USDC majors; these are the same mechanism
+   with a dex-prefixed coin.
 
 No memecoins. No unlisted low-liquidity tokens. Liquidity and a legible thesis gate every name.
 
 ## Risk controls (hard limits)
 - **Max risk per trade:** 5% of current GMAC balance. In SURVIVE mode, 2%.
-- **Max leverage:** 3x. Set it explicitly in the order (`leverage`), never rely on HL's 20x default.
+- **Max leverage:** 3x. Set it explicitly in the order (`leverage`) — verified to land at exactly 3x
+  (isolated on builder dexes). Never rely on HL's 20x default; there is no separate set_leverage call.
 - **Always** set TP and SL when opening a perp. No naked positions.
 - **One or two open theses at a time.** No scattering risk across many names.
 - Keep dry powder: never deploy the whole treasury; the survival buffer is sacred.

--- a/references/mcp-trading.md
+++ b/references/mcp-trading.md
@@ -21,6 +21,9 @@ The session is now live. Keep `sessionPrivateKey` and `apiKey` for the trade cal
 ## Reads (no auth, use the managed address from step 3)
 
 - `mcp__gdex__get_hl_clearinghouse_state` `{ userAddress: <managed> }` — perp equity, positions, withdrawable. Authoritative.
+  - **Builder/HIP-3 positions are dex-scoped.** A `xyz:NVDA` position appears only when you pass
+    `{ dex: "xyz" }`; the default query won't show it (looks like "nothing filled" when it actually filled).
+    Read each builder dex you hold, not just the default — collateral/positions migrate to that dex's isolated account.
 - `mcp__gdex__get_hl_spot_state` `{ walletAddress: <managed> }` — spot USDC (where idle capital sits).
 - `mcp__gdex__get_hl_open_orders` `{ walletAddress: <managed> }` — resting TP/SL legs.
 - `mcp__gdex__get_mark_price` `{ coin }` · `mcp__gdex__get_hl_meta_and_asset_ctxs` — marks, funding, OI.

--- a/references/trading.md
+++ b/references/trading.md
@@ -24,9 +24,14 @@ Read the managed addresses from the wallet JSON (`~/gdex-test-wallet.json`):
 
 - `get_hl_clearinghouse_state` with `userAddress = <managed HL address>` and `dex: "default"` —
   authoritative perp account: `accountValue`, `withdrawable`, positions. **Use this one.**
+- **Builder/HIP-3 positions live under their own dex, NOT `default`.** A `xyz:NVDA` position
+  shows up only when you query with `dex: "xyz"` — querying `default` returns it empty and looks
+  like "nothing filled." When holding builder-dex perps, read each dex you trade (`dex: "xyz"`),
+  not just `default`. (Live-confirmed: `xyz:NVDA`/`xyz:SPCX` opened fine but were invisible under
+  `default` — the position migrates to the builder dex's isolated account.)
 - `get_usdc_balance` / `get_hl_spot_state` with the managed HL address — HL USDC and spot balances.
 - `get_account_state` can return `$0` for a funded account if it hits a different/empty builder DEX —
-  trust `get_hl_clearinghouse_state` with `dex: "default"` over it.
+  trust `get_hl_clearinghouse_state` (with the right `dex`) over it.
 - `get_portfolio` / `get_balances` are known-buggy (wrong params); for spot use the raw
   `client.get('/v1/portfolio', {userId, chainId, data})` flow. Note **native SOL/ETH are NOT in
   `portfolio.holding[]`** — check native balance separately.
@@ -53,21 +58,38 @@ tightest spreads, and the most reliable funding — the opposite of memecoin ris
   Use as a *sentiment* read, not a copy signal, unless explicitly running copy-trading.
 - `get_hl_user_stats` — a specific trader's stats by address (`ethAddress`).
 
-**Act — use the bundled execution helper, not the MCP write tools.** The MCP
-`open_perp_position`/`set_leverage` tools require a freshly-signed managed session
-that cannot be threaded cleanly through tool calls. `scripts/hl_perp.js` performs
-the proven sign-in (chainId 42161, fresh session, 0x-stripped signature) and
-trades on the managed account. It emits JSON.
+**Act — `open_perp_position` (MCP) or `scripts/hl_perp.js` (fallback).** Both do the
+proven sign-in (chainId 42161, fresh session, 0x-stripped signature) and trade on the
+managed account. The helper emits JSON.
 
 - `node scripts/hl_perp.js status` — spot USDC, account value, positions, open orders.
-- `node scripts/hl_perp.js open --coin ETH --side long --notional 12 --sl-pct 2 --tp-pct 3`
+- `node scripts/hl_perp.js open --coin ETH --side long --notional 12 --leverage 3 --sl-pct 2 --tp-pct 3`
   — market entry with reduce-only TP/SL legs. A stop is mandatory; the $11 HL minimum is enforced.
 - `node scripts/hl_perp.js close --coin ETH` — reduce-only market close, realizing PnL.
 
-HyperLiquid applies its default cross leverage (e.g. 20x) unless changed; risk is
-bounded by the **stop**, not the leverage, so keep size small and the stop tight.
-The MCP read tools (`get_mark_price`, `get_hl_meta_and_asset_ctxs`,
+**Leverage is settable and you must set it.** Pass `leverage` in the open (the MCP
+`open_perp_position` tool and `hl_perp.js --leverage` both forward it as a top-level
+field on the order). HL defaults to **20x** if you omit it — never rely on that. The
+strategy cap is **≤3x**. There is no separate `set_leverage` call (that endpoint is
+404). Live-confirmed: opens land at exactly the leverage passed (3x isolated on builder
+dexes, 3x on default). The MCP read tools (`get_mark_price`, `get_hl_meta_and_asset_ctxs`,
 `get_hl_clearinghouse_state`) remain the way to gather intel.
+
+### Builder/HIP-3 perps (stocks, commodities — verified working)
+
+Beyond the default USDC dex, HL exposes builder dexes with stock and commodity perps:
+`xyz:NVDA`, `xyz:TSLA`, `xyz:SPCX` (SpaceX), oil, etc. These are **USDC-collateralized,
+24-hour markets** — no collateral swap needed. To trade them:
+
+- Pass the coin with the **lowercase dex prefix** (`xyz:NVDA`, not `XYZ:NVDA`); the SDK
+  normalizes casing but feed it correctly.
+- Use the per-asset mark from `get_hl_all_assets` / `get_hl_meta_and_asset_ctxs` — plain
+  `get_mark_price` returns 0 for builder coins.
+- They open **isolated** automatically and honor the `leverage` you pass (3x verified live).
+- Read the resulting position with `get_hl_clearinghouse_state { dex: "xyz" }`, not `default`.
+
+Lead with default-dex USDC majors; treat builder stock/commodity perps as the same
+mechanism with a dex-prefixed coin and a dex-scoped position read.
 
 **Discipline:**
 - One thesis per trade, stated before you open it.

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -66,6 +66,54 @@ async function szDecimalsFor(skill, coin) {
   return SZ_DECIMALS[coin] ?? 2;
 }
 
+function mapPositions(aps) {
+  return (aps || [])
+    .map((p) => p.position || p)
+    .filter((p) => Number(p.szi ?? p.size) !== 0)
+    .map((p) => ({
+      coin: p.coin,
+      size: Number(p.szi ?? p.size),
+      entryPx: Number(p.entryPx),
+      unrealizedPnl: Number(p.unrealizedPnl),
+      liquidationPx: p.liquidationPx ?? null,
+    }));
+}
+
+// Builder/HIP-3 dex prefixes (xyz, flx, …) present in the tradable universe.
+async function builderDexes(skill) {
+  const a = await skill.getHlAllAssets().catch(() => []);
+  const arr = Array.isArray(a) ? a : a.data || a.assets || a.universe || [];
+  const set = new Set();
+  for (const x of arr) {
+    const c = String(x.coin || '');
+    const i = c.indexOf(':');
+    if (i !== -1) set.add(c.slice(0, i).toLowerCase());
+  }
+  return [...set];
+}
+
+// True equity + positions across default AND every builder dex. Builder/HIP-3
+// positions (xyz:NVDA, …) live under their own dex, not `default`. The bundled
+// "…StateAll" endpoint is stale (omits xyz), so query each dex explicitly via the
+// object form `{ userAddress, dex }` — the only reliable way to see migrated collateral.
+async function fullState(skill, managed) {
+  const dexes = await builderDexes(skill);
+  const [def, ...rest] = await Promise.all([
+    skill.getHlClearinghouseState(managed).catch(() => null),
+    ...dexes.map((dex) => skill.getHlClearinghouseState({ userAddress: managed, dex }).catch(() => null)),
+  ]);
+  const defRoot = def?.state || def || {};
+  let accountValue = Number(defRoot.marginSummary?.accountValue || 0);
+  const positions = mapPositions(defRoot.assetPositions);
+  for (const cs of rest) {
+    const root = cs?.state || cs;
+    if (!root) continue;
+    accountValue += Number(root.marginSummary?.accountValue || 0);
+    positions.push(...mapPositions(root.assetPositions));
+  }
+  return { accountValue, positions, withdrawable: Number(defRoot.withdrawable || 0) };
+}
+
 function die(msg) {
   process.stdout.write(JSON.stringify({ ok: false, error: msg }) + '\n');
   process.exit(1);
@@ -121,12 +169,12 @@ async function signedSkill(wallet) {
 async function cmdStatus(wallet) {
   const { skill } = await signedSkill(wallet);
   // Resilient: a transient non-JSON response on one read shouldn't fail the whole status.
-  const [stateR, spotR, ordersR] = await Promise.allSettled([
-    skill.getHlAccountState(wallet.managed),
+  const [fullR, spotR, ordersR] = await Promise.allSettled([
+    fullState(skill, wallet.managed),
     skill.getHlSpotState(wallet.managed),
     skill.getHlOpenOrders(wallet.managed),
   ]);
-  const state = stateR.status === 'fulfilled' ? stateR.value : { accountValue: 0, positions: [] };
+  const full = fullR.status === 'fulfilled' ? fullR.value : { accountValue: 0, positions: [], withdrawable: 0 };
   const spot = spotR.status === 'fulfilled' ? spotR.value : { balances: [] };
   const orders = ordersR.status === 'fulfilled' ? ordersR.value : [];
   const usdc = (spot.balances || []).find((b) => b.coin === 'USDC');
@@ -134,14 +182,9 @@ async function cmdStatus(wallet) {
     ok: true,
     managed: wallet.managed,
     spotUsdc: usdc ? Number(usdc.total) : 0,
-    accountValue: Number(state.accountValue),
-    positions: (state.positions || []).map((p) => ({
-      coin: p.coin || p.position?.coin,
-      size: Number(p.size ?? p.szi ?? p.position?.szi),
-      entryPx: Number(p.entryPx ?? p.position?.entryPx),
-      unrealizedPnl: Number(p.unrealizedPnl ?? p.position?.unrealizedPnl),
-      liquidationPx: p.liquidationPx ?? p.position?.liquidationPx ?? null,
-    })),
+    accountValue: full.accountValue, // total tradable equity across default + builder dexes
+    withdrawable: full.withdrawable,
+    positions: full.positions, // includes builder-dex (xyz:*) positions
     openOrders: (orders || []).map((o) => ({ coin: o.coin, px: Number(o.limitPx), sz: Number(o.sz), reduceOnly: !!o.reduceOnly })),
   };
 }
@@ -182,14 +225,30 @@ async function cmdOpen(wallet, args) {
   return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', leverage, mark: px, size, notional: Number(notional.toFixed(2)), sl, tp };
 }
 
+// Resolve a position's signed size from the coin's own dex (builder coins live
+// under their dex's isolated account, not the default clearinghouse).
+async function positionSize(skill, managed, coin) {
+  const i = coin.indexOf(':');
+  if (i === -1) {
+    const state = await skill.getHlAccountState(managed);
+    const pos = (state.positions || []).find(
+      (p) => String(p.coin || p.position?.coin).toLowerCase() === coin.toLowerCase(),
+    );
+    return pos ? Number(pos.size ?? pos.szi ?? pos.position?.szi) : 0;
+  }
+  const cs = await skill
+    .getHlClearinghouseState({ userAddress: managed, dex: coin.slice(0, i).toLowerCase() })
+    .catch(() => null);
+  const pos = mapPositions((cs?.state || cs)?.assetPositions).find(
+    (p) => String(p.coin).toLowerCase() === coin.toLowerCase(),
+  );
+  return pos ? pos.size : 0;
+}
+
 async function cmdClose(wallet, args) {
   const coin = normalizeCoin(args.coin || 'ETH');
   const { skill, creds } = await signedSkill(wallet);
-  const state = await skill.getHlAccountState(wallet.managed);
-  const pos = (state.positions || []).find(
-    (p) => String(p.coin || p.position?.coin).toLowerCase() === coin.toLowerCase(),
-  );
-  const szi = pos ? Number(pos.size ?? pos.szi ?? pos.position?.szi) : 0;
+  const szi = await positionSize(skill, wallet.managed, coin);
   if (!szi) return { ok: true, action: 'close', coin, note: 'no open position' };
   const px = await markPriceFor(skill, coin);
   const res = await skill.hlCreateOrder({


### PR DESCRIPTION
## What

The agent could open builder/HIP-3 stock perps (`xyz:NVDA`, `xyz:SPCX`, …) but couldn't *see* them. Those positions live under their own dex's isolated account, not the default clearinghouse, and `hl_perp.js status` read only the default dex — so a filled `xyz` position showed as "no position" and its equity was missing. That misread is what looked like "orders don't fill."

Verified against HyperLiquid's own fill record: the orders execute and land at the leverage passed (3× isolated), with two live `xyz` positions the old `status` reported as empty.

## Changes

- **`status`** sums equity and merges positions across the default dex **and every builder dex**. The dex set comes from `getHlAllAssets`; each is queried via the object form `getHlClearinghouseState({ userAddress, dex })`. The bundled `getHlClearinghouseStateAll` is **stale — it omits the `xyz` dex** — so it is not used.
- **`close`** resolves the position size from the coin's own dex, so builder coins can be flattened (previously returned "no open position").
- **Docs** (`trading.md`, `mcp-trading.md`, `TRADING_STRATEGY.md`): builder/HIP-3 stock perps are USDC-collateralized and 24h (no collateral swap); positions are dex-scoped reads; leverage is settable and lands at the value passed.

## Verification

`node scripts/hl_perp.js status` now returns `accountValue 24.49` (default 16.42 + xyz 8.07) with both `xyz:NVDA` and `xyz:SPCX` positions (size, entry, uPnL, liq) — previously `accountValue 0`, empty positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)