### PR TITLE
Technique forge: agents author, prove, and trade their own skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ with `gdex_sign.js` providing the one local signature managed custody can't dele
 | `scripts/evolve.py` | goodwill-gated `replicate/recode/capabilities` |
 | `scripts/gdex_sign.js` | instant local sign-in signer (pure crypto) |
 | `scripts/hl_perp.js` | SDK fallback executor (`status/open/close`) |
+| `scripts/forge.py` + `scripts/forge_data.js` | technique forge — author/prove/adopt/run self-made trading skills |
 | `references/` | `mcp-trading.md` (primary), `trading.md`, `metabolism.md`, `evolution.md` |
 
 ## Build / test / lint

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,7 @@ itself about its own balance.
 - `scripts/swarm.py` — leader coordination (`status`/`signals`/`consensus`/`assign`); goodwill ≥ 200.
 - `scripts/venture.py` + `scripts/venture_deploy.js` + `contracts/GmacBuyAndBurn.sol` — Venture Architect (goodwill ≥ 5000): deploy DeFi infra with a perpetual GMAC buy-and-burn. See `references/venture.md`.
 - `scripts/autosettle.js` — deterministic realized-PnL settle from HL fills (`run`/`peek`).
+- `scripts/forge.py` + `scripts/forge_data.js` — technique forge: author/prove/adopt/run self-made trading skills (`draft`/`prove`/`adopt`/`run`); `references/forge.md`.
 - `scripts/dashboard.py` — renders the DNA visualization (`render` / `serve`).
 - `scripts/gmac_buy.js` — GMAC buy-back (`plan` / `buy`); `references/gmac.md`.
 - `scripts/erc8004_register.js` — ERC-8004 identity mint, self + `--child <name>` (`dry-run`/`broadcast`); `references/onchain-identity.md`.
@@ -80,6 +81,10 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
 5. **Intelligence.** `mcp__gdex__get_mark_price`, `get_hl_meta_and_asset_ctxs`, optionally
    `get_hl_top_traders_by_pnl`. For events: `hl_outcomes`.
 6. **Decide & act (MCP).** At most one or two conservative moves consistent with the strategy and `mode`.
+   - **Consult your techniques first.** `uv run --no-project python3 scripts/forge.py run` evaluates your
+     adopted, *proven* techniques on their live markets and returns cap-checked intents (ranked by
+     confidence). Treat the top intent as a strong prior; act on it (or `forge.py run --execute` to place
+     it directly within the caps). See `references/forge.md`. Empty intents = no setup; don't force a trade.
    - Open perp: `mcp__gdex__open_perp_position` with `{apiKey, walletAddress: <control>, sessionPrivateKey,
      coin, isLong, price: <mark>, size, tpPrice, slPrice, leverage}`. **Pass `leverage` in the order** (≤3x per
      strategy; HL defaults to 20x if omitted) — there is no separate set_leverage call. A stop is mandatory;
@@ -100,6 +105,11 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
    **Swarm (goodwill ≥ 200):** run `scripts/swarm.py signals` and `consensus` to aggregate the children's
    reads and spot crowding, act on the consensus, then `swarm.py assign` so each child takes a distinct
    asset — the family stops piling into one side. See `references/evolution.md`.
+   **Forge a technique.** When you notice a repeatable edge in how your trades worked, codify it:
+   `forge.py draft "<name>" --claim "<edge>"`, write the logic into the technique's `signal.py`, then
+   `forge.py prove <id> --coin <c> --interval <i>`. It graduates only if it has out-of-sample edge — if so,
+   `forge.py adopt <id>` and it joins your style from the next heartbeat. This is how your trading style
+   becomes your own, earned skill rather than fixed rules. Full lifecycle + safety model: `references/forge.md`.
 9. **Chatter (the show).** Send ONE short in-character line to the family bus about how the cycle
    went, in this creature's voice (read its `persona.json`): `telepathy.py send --to broadcast --type
    market_insight --msg "<banter>"`. This is what people watch — keep it alive, not a report.

--- a/references/forge.md
+++ b/references/forge.md
@@ -1,0 +1,122 @@
+# Technique forge — author, prove, and trade your own skills
+
+The forge lets a Gclaw agent turn experience into a **technique**: a small,
+self-authored skill that decides trades, earns a track record on real market
+history, and joins the agent's trading **style**. It is the bridge from "I
+noticed a pattern" to "I trade a proven edge" — and, in v2, to trading that
+edge *with other agents*.
+
+Engine: `scripts/forge.py` (stdlib Python) + `scripts/forge_data.js` (HyperLiquid
+candles/features, no auth). State lives under `$GCLAW_HOME/forge/`.
+
+## The loop
+
+```
+draft   forge.py draft "<name>" --kind edge --claim "<the edge in one line>"
+        → scaffolds $GCLAW_HOME/forge/techniques/<id>/ (technique.json, SKILL.md, signal.py)
+        → then YOU write the logic into signal.py
+prove   forge.py prove <id> --coin ETH --interval 4h
+        → walk-forward backtest over real candles; writes card.json
+        → graduates to "proven" ONLY if in-sample AND out-of-sample expectancy > 0
+          with n_oos ≥ 20. Regime-lucky techniques are refused.
+adopt   forge.py adopt <id>        → adds it to style.json on its proven market
+run     forge.py run               → evaluate adopted techniques on live data
+        forge.py run --execute     → place the top intent, within the risk caps
+list/show/drop                     → manage the loadout
+```
+
+## What a technique is
+
+`signal.py` exports one pure function:
+
+```python
+def signal(f):
+    """f: feature dict → a decision dict (or flat)."""
+```
+
+**Features** (`f`):
+- Always (price-derived, available in backtest and live): `coin, price, ret1,
+  ret4, ret24` (1/4/24-bar returns), `vol` (stdev of 1-bar returns), `mom`
+  (price vs 24-bar SMA), `rng` (avg bar range).
+- Live only (`None` in backtests — treat `None` as neutral): `funding`, `oi`,
+  `premium`.
+
+**Decision** (return value):
+```python
+{"action": "long" | "short" | "flat",
+ "confidence": 0.0-1.0,     # ranks competing intents
+ "leverage": 1-3,           # clamped to the cap regardless
+ "stop_pct": > 0,           # MANDATORY; a flat/zero-stop intent is dropped
+ "reason": "human-readable"}
+```
+
+## Worked example — `vol-momentum` (proven, ETH 4h)
+
+Follow the 24-bar trend when momentum and the last bar agree and volatility is
+contained; stand aside in chop. Stop scales with volatility.
+
+```python
+def signal(f):
+    trend = f["ret24"]; mom = f["mom"]; ret1 = f["ret1"]
+    vol = f["vol"] or 0.01
+    stop_pct = max(1.5, round(vol * 220, 2))
+    calm = vol < 0.02
+    if calm and trend > 0.012 and mom > 0 and ret1 > 0:
+        return {"action": "long", "confidence": min(1.0, abs(trend) * 18),
+                "leverage": 3, "stop_pct": stop_pct, "reason": f"up trend {trend:+.3f}"}
+    if calm and trend < -0.012 and mom < 0 and ret1 < 0:
+        return {"action": "short", "confidence": min(1.0, abs(trend) * 18),
+                "leverage": 3, "stop_pct": stop_pct, "reason": f"down trend {trend:+.3f}"}
+    return {"action": "flat", "confidence": 0.0, "stop_pct": stop_pct, "reason": "chop"}
+```
+
+Its proven card (out-of-sample): `n=159, winrate 0.39, expectancy +0.00018,
+total +2.8%` — a trend-follower's profile (many small losses, fewer larger
+wins). The same signal is *refused* on BTC 4h, where in-sample expectancy is
+negative. That refusal is the point.
+
+## The evidence gate (why this is trustworthy, not lore)
+
+A technique cannot go live until a backtest it did not get to tune proves edge:
+- **Walk-forward split** — first 60% in-sample, last 40% out-of-sample.
+- **Both sides must be positive** and `n_oos ≥ 20`. OOS-only edge = luck/regime.
+- **Costs are charged** — every backtest trade pays a taker+slippage estimate.
+- **Stops are simulated** on bar highs/lows, not assumed.
+
+No self-reported performance. The card is computed by a shared harness.
+
+## Safety model (full autonomy *within* caps)
+
+A technique decides the trade; the forge enforces the rails — they are not
+optional and a technique cannot widen them:
+- **Sandbox** — `signal.py` may import only `math`/`statistics`; `eval`, `open`,
+  `os`, `__import__`, dunder access, etc. are rejected by an AST check before the
+  code ever runs, and execution is wall-clock capped.
+- **Caps** — leverage clamped to **≤3×**; a **stop is mandatory**; size comes
+  from the risk budget (5% equity in THRIVE, 2% in SURVIVE) divided by the stop;
+  HIBERNATE blocks execution; the **$11 HL minimum** is enforced.
+- **One execution path** — `run --execute` places trades only through
+  `hl_perp.js`, which re-applies every cap. A technique never touches execution
+  directly.
+
+## Provenance — riding the onchain identity
+
+Every technique is stamped with the agent's `author` = its ERC-8004 `agentId`
+(from `metabolism.json`, e.g. `55624` on Base) and an optional `parent` for
+lineage. This is what makes v2 possible: when techniques are **published** to the
+shared gene pool, their author, lineage, and proven card are anchored to a real
+onchain identity — so reputation and royalties are portable and verifiable, not
+claimed.
+
+## Roadmap (v2 — the collaborative market)
+
+The solo loop above is v1. Next, riding the same onchain identity:
+- **publish / discover** — proven techniques enter a shared gene pool, ranked by
+  out-of-sample edge and author reputation.
+- **critique** — before adopting a peer's technique, an agent adversarially
+  re-proves it (fresh data, look-ahead/overfit checks) and attaches a verdict.
+- **fork / merge** — improve a peer's technique; lineage is tracked.
+- **royalties / reputation** — a technique that earns PnL for its adopters
+  credits GMAC and reputation to its author, anchored onchain.
+- **tournaments** — styles compete on a shared benchmark (the decentralized
+  leaderboard); winners are boosted in discovery. Natural selection for skills.

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Gclaw technique forge — agents author, prove, and trade their own skills.
+
+A *technique* is a small skill the agent writes for itself: a pure
+``signal(features) -> decision`` function plus a perf card earned on real
+market history. The loop is deterministic file operations, not magic:
+
+  draft   scaffold a technique dir (technique.json, SKILL.md, signal.py)
+  prove   backtest signal.py over HyperLiquid candles, walk-forward, and
+          write a perf card; only out-of-sample edge graduates it
+  adopt   add a proven technique to the agent's style loadout (style.json)
+  run     evaluate adopted techniques on live features and, with --execute,
+          trade the top intent through hl_perp.js under the global risk caps
+
+Every technique is stamped with the agent's onchain identity (agentId from
+metabolism.json), so provenance and reputation are portable to the gene pool.
+Generated signal.py is constrained by an import allow-list and executed with a
+wall-clock cap; the agent has full autonomy *within* the risk caps enforced in
+``run`` (leverage <= MAX_LEVERAGE, mandatory stop, $11 min, mode gating).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import signal as signalmod
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+# Risk caps (mirror dna/TRADING_STRATEGY.md — enforced, never bypassable).
+MAX_LEVERAGE = 3
+RISK_PCT = {"thrive": 5, "survive": 2, "hibernate": 0}
+MIN_NOTIONAL = 11
+
+# Evidence gate.
+MIN_OOS_SAMPLE = 20
+IS_FRACTION = 0.6
+HORIZON = 4          # bars held per backtest trade
+TAKER_COST = 0.0006  # round-trip fee + slippage estimate
+WARMUP = 26          # bars before features are valid
+
+# signal.py sandbox.
+ALLOWED_IMPORTS = {"math", "statistics"}
+BANNED_NAMES = {
+    "eval", "exec", "open", "__import__", "compile", "input", "globals",
+    "locals", "getattr", "setattr", "vars", "delattr", "memoryview",
+}
+SIGNAL_TIMEOUT_S = 2
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def gclaw_home() -> Path:
+    return Path(os.environ.get("GCLAW_HOME", str(Path.home() / ".gclaw")))
+
+
+def forge_dir() -> Path:
+    d = gclaw_home() / "forge" / "techniques"
+    d.mkdir(parents=True, exist_ok=True)
+    return d.parent
+
+
+def tech_dir(tid: str) -> Path:
+    return forge_dir() / "techniques" / tid
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:48] or "technique"
+
+
+def load_metabolism() -> dict[str, Any]:
+    path = gclaw_home() / "metabolism.json"
+    if not path.exists():
+        return {"mode": "thrive", "onchain_identity": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def agent_id() -> str:
+    ident = load_metabolism().get("onchain_identity") or {}
+    return str(ident.get("agentId") or "local")
+
+
+def die(msg: str) -> None:
+    print(json.dumps({"ok": False, "error": msg}))
+    sys.exit(1)
+
+
+# ── Market data (via the node bridge) ────────────────────────────────────────
+
+
+def run_node(args: list[str]) -> dict[str, Any]:
+    """Call forge_data.js and return its parsed JSON, or raise on failure."""
+    proc = subprocess.run(
+        ["node", str(SCRIPT_DIR / "forge_data.js"), *args],
+        capture_output=True, text=True, timeout=60,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "forge_data.js failed")
+    data = json.loads(proc.stdout.strip().splitlines()[-1])
+    if not data.get("ok"):
+        raise RuntimeError(data.get("error", "forge_data.js error"))
+    return data
+
+
+def get_candles(coin: str, interval: str, limit: int) -> list[dict[str, float]]:
+    return run_node(["candles", "--coin", coin, "--interval", interval,
+                     "--limit", str(limit)])["candles"]
+
+
+def get_live_features(coins: list[str]) -> dict[str, Any]:
+    return run_node(["features", "--coins", ",".join(coins)])["features"]
+
+
+# ── Feature engineering ──────────────────────────────────────────────────────
+
+
+def features_at(candles: list[dict[str, float]], i: int, coin: str,
+                live: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Build the feature dict the signal sees at bar ``i`` (price-derived).
+
+    funding/oi/premium are live-only (None in backtests) — a robust signal
+    treats None as neutral. ``live`` injects them when running on real time.
+    """
+    closes = [candles[k]["c"] for k in range(i - 24, i + 1)]
+    rets = [closes[k] / closes[k - 1] - 1 for k in range(1, len(closes))]
+    price = candles[i]["c"]
+    sma = statistics.fmean(closes)
+    rng = statistics.fmean(
+        (candles[k]["h"] - candles[k]["l"]) / candles[k]["c"] for k in range(i - 23, i + 1)
+    )
+    f: dict[str, Any] = {
+        "coin": coin,
+        "price": price,
+        "ret1": price / candles[i - 1]["c"] - 1,
+        "ret4": price / candles[i - 4]["c"] - 1,
+        "ret24": price / candles[i - 24]["c"] - 1,
+        "vol": statistics.pstdev(rets),
+        "mom": price / sma - 1,
+        "rng": rng,
+        "funding": None,
+        "oi": None,
+        "premium": None,
+    }
+    if live:
+        f["funding"] = live.get("funding")
+        f["oi"] = live.get("openInterest")
+        f["premium"] = live.get("premium")
+    return f
+
+
+# ── signal.py sandbox ────────────────────────────────────────────────────────
+
+
+def validate_signal_src(src: str) -> list[str]:
+    """Return a list of policy violations in a technique's signal source."""
+    violations: list[str] = []
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as exc:
+        return [f"syntax error: {exc}"]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] not in ALLOWED_IMPORTS:
+                    violations.append(f"import not allowed: {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] not in ALLOWED_IMPORTS:
+                violations.append(f"import not allowed: from {node.module}")
+        elif isinstance(node, ast.Name) and node.id in BANNED_NAMES:
+            violations.append(f"banned name: {node.id}")
+        elif isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            violations.append(f"dunder access not allowed: {node.attr}")
+    if not any(isinstance(n, ast.FunctionDef) and n.name == "signal"
+               for n in ast.walk(tree)):
+        violations.append("missing required function: signal(features)")
+    return violations
+
+
+def load_signal(tid: str) -> Callable[[dict[str, Any]], Any]:
+    """Validate and import a technique's signal function."""
+    src_path = tech_dir(tid) / "signal.py"
+    if not src_path.exists():
+        die(f"no signal.py for technique '{tid}'")
+    src = src_path.read_text(encoding="utf-8")
+    violations = validate_signal_src(src)
+    if violations:
+        die(f"signal.py rejected: {'; '.join(violations)}")
+    namespace: dict[str, Any] = {}
+    exec(compile(src, str(src_path), "exec"), namespace)  # noqa: S102 — AST-validated above
+    return namespace["signal"]
+
+
+def _timeout(_signum: int, _frame: Any) -> None:
+    raise TimeoutError("signal exceeded time budget")
+
+
+def call_signal(fn: Callable[[dict[str, Any]], Any], f: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Call signal(features) with a wall-clock cap and validate the decision."""
+    signalmod.signal(signalmod.SIGALRM, _timeout)
+    signalmod.setitimer(signalmod.ITIMER_REAL, SIGNAL_TIMEOUT_S)
+    try:
+        out = fn(dict(f))
+    finally:
+        signalmod.setitimer(signalmod.ITIMER_REAL, 0)
+    if not isinstance(out, dict):
+        return None
+    action = out.get("action")
+    if action not in ("long", "short", "flat"):
+        return None
+    return out
+
+
+# ── Backtest ─────────────────────────────────────────────────────────────────
+
+
+def trade_return(candles: list[dict[str, float]], i: int, is_long: bool, stop_pct: float) -> float:
+    """Forward return of a HORIZON-bar trade opened at bar i close, with a stop."""
+    entry = candles[i]["c"]
+    stop = stop_pct / 100.0
+    for h in range(1, HORIZON + 1):
+        bar = candles[i + h]
+        if is_long and bar["l"] <= entry * (1 - stop):
+            return -stop - TAKER_COST
+        if not is_long and bar["h"] >= entry * (1 + stop):
+            return -stop - TAKER_COST
+    exit_px = candles[i + HORIZON]["c"]
+    raw = (exit_px / entry - 1) if is_long else (entry / exit_px - 1)
+    return raw - TAKER_COST
+
+
+def score_window(candles: list[dict[str, float]], fn: Callable[[dict[str, Any]], Any],
+                 coin: str, lo: int, hi: int) -> dict[str, Any]:
+    """Run the signal across bars [lo, hi) and summarise the trades."""
+    rets: list[float] = []
+    for i in range(lo, hi):
+        decision = call_signal(fn, features_at(candles, i, coin))
+        if not decision or decision["action"] == "flat":
+            continue
+        stop_pct = float(decision.get("stop_pct") or 0)
+        if stop_pct <= 0:
+            continue
+        rets.append(trade_return(candles, i, decision["action"] == "long", stop_pct))
+    return summarise(rets)
+
+
+def summarise(rets: list[float]) -> dict[str, Any]:
+    if not rets:
+        return {"n": 0, "winrate": 0.0, "expectancy": 0.0, "total": 0.0, "max_dd": 0.0}
+    equity, peak, max_dd = 0.0, 0.0, 0.0
+    for r in rets:
+        equity += r
+        peak = max(peak, equity)
+        max_dd = min(max_dd, equity - peak)
+    wins = sum(1 for r in rets if r > 0)
+    return {
+        "n": len(rets),
+        "winrate": round(wins / len(rets), 4),
+        "expectancy": round(statistics.fmean(rets), 6),
+        "total": round(equity, 6),
+        "max_dd": round(max_dd, 6),
+    }
+
+
+def backtest(tid: str, coin: str, interval: str, limit: int) -> dict[str, Any]:
+    """Walk-forward backtest: fit-free IS/OOS split, gate on out-of-sample edge."""
+    fn = load_signal(tid)
+    candles = get_candles(coin, interval, limit)
+    if len(candles) < WARMUP + HORIZON + 60:
+        die(f"not enough candles ({len(candles)}) — widen --limit or --interval")
+    last = len(candles) - HORIZON
+    split = WARMUP + int((last - WARMUP) * IS_FRACTION)
+    is_stats = score_window(candles, fn, coin, WARMUP, split)
+    oos_stats = score_window(candles, fn, coin, split, last)
+    proven = (oos_stats["n"] >= MIN_OOS_SAMPLE
+              and oos_stats["expectancy"] > 0
+              and is_stats["expectancy"] > 0)
+    return {
+        "coin": coin, "interval": interval, "bars": len(candles),
+        "in_sample": is_stats, "out_of_sample": oos_stats,
+        "proven": proven, "proved_at": now_iso(),
+    }
+
+
+# ── Style loadout ────────────────────────────────────────────────────────────
+
+
+def load_style() -> dict[str, Any]:
+    path = forge_dir() / "style.json"
+    if not path.exists():
+        return {"agent": agent_id(), "adopted": [], "updated_at": now_iso()}
+    style = json.loads(path.read_text(encoding="utf-8"))
+    style["adopted"] = [
+        e if isinstance(e, dict) else {"id": e, "coin": "BTC", "interval": "1h"}
+        for e in style.get("adopted", [])
+    ]
+    return style
+
+
+def save_style(style: dict[str, Any]) -> None:
+    style["updated_at"] = now_iso()
+    (forge_dir() / "style.json").write_text(json.dumps(style, indent=2), encoding="utf-8")
+
+
+def load_technique(tid: str) -> dict[str, Any]:
+    path = tech_dir(tid) / "technique.json"
+    if not path.exists():
+        die(f"no technique '{tid}'")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_technique(tech: dict[str, Any]) -> None:
+    (tech_dir(tech["id"]) / "technique.json").write_text(
+        json.dumps(tech, indent=2), encoding="utf-8")
+
+
+# ── Verbs ────────────────────────────────────────────────────────────────────
+
+
+def cmd_draft(args: argparse.Namespace) -> dict[str, Any]:
+    """Scaffold a new technique the agent then fills in (signal.py)."""
+    tid = slugify(args.name)
+    d = tech_dir(tid)
+    if d.exists() and not args.force:
+        die(f"technique '{tid}' exists — use --force to overwrite")
+    d.mkdir(parents=True, exist_ok=True)
+    tech = {
+        "id": tid, "name": args.name, "kind": args.kind,
+        "author": agent_id(), "parent": args.parent,
+        "claim": args.claim or "", "status": "draft",
+        "created_at": now_iso(),
+    }
+    save_technique(tech)
+    (d / "SKILL.md").write_text(SKILL_TEMPLATE.format(
+        name=args.name, kind=args.kind, claim=args.claim or "(state the edge)",
+        author=tech["author"]), encoding="utf-8")
+    if not (d / "signal.py").exists() or args.force:
+        (d / "signal.py").write_text(SIGNAL_TEMPLATE, encoding="utf-8")
+    return {"ok": True, "drafted": tid, "dir": str(d),
+            "next": "edit signal.py, then: forge.py prove " + tid}
+
+
+def cmd_prove(args: argparse.Namespace) -> dict[str, Any]:
+    card = backtest(args.id, args.coin, args.interval, args.limit)
+    (tech_dir(args.id) / "card.json").write_text(json.dumps(card, indent=2), encoding="utf-8")
+    tech = load_technique(args.id)
+    tech["status"] = "proven" if card["proven"] else "draft"
+    tech["card"] = {"coin": card["coin"], "interval": card["interval"],
+                    "oos": card["out_of_sample"], "proven": card["proven"]}
+    save_technique(tech)
+    return {"ok": True, "id": args.id, "proven": card["proven"], "card": card}
+
+
+def cmd_adopt(args: argparse.Namespace) -> dict[str, Any]:
+    tech = load_technique(args.id)
+    if tech.get("status") != "proven" and not args.force:
+        die(f"technique '{args.id}' is not proven — prove it first (or --force)")
+    card = tech.get("card") or {}
+    entry = {"id": args.id, "coin": card.get("coin", "BTC"),
+             "interval": card.get("interval", "1h")}
+    style = load_style()
+    style["adopted"] = [e for e in style["adopted"] if e["id"] != args.id] + [entry]
+    save_style(style)
+    return {"ok": True, "adopted": style["adopted"]}
+
+
+def cmd_drop(args: argparse.Namespace) -> dict[str, Any]:
+    style = load_style()
+    style["adopted"] = [e for e in style["adopted"] if e["id"] != args.id]
+    save_style(style)
+    return {"ok": True, "adopted": style["adopted"]}
+
+
+def cmd_list(_args: argparse.Namespace) -> dict[str, Any]:
+    techs = []
+    for d in sorted((forge_dir() / "techniques").glob("*/")):
+        t = json.loads((d / "technique.json").read_text(encoding="utf-8"))
+        techs.append({"id": t["id"], "kind": t["kind"], "status": t["status"],
+                      "author": t["author"], "claim": t.get("claim", "")[:60]})
+    return {"ok": True, "adopted": load_style()["adopted"], "techniques": techs}
+
+
+def cmd_show(args: argparse.Namespace) -> dict[str, Any]:
+    tech = load_technique(args.id)
+    card_path = tech_dir(args.id) / "card.json"
+    if card_path.exists():
+        tech["card_full"] = json.loads(card_path.read_text(encoding="utf-8"))
+    return {"ok": True, "technique": tech}
+
+
+def _equity_usd() -> float:
+    """Read HL account value via hl_perp.js (best effort; 0 on failure)."""
+    try:
+        proc = subprocess.run(["node", str(SCRIPT_DIR / "hl_perp.js"), "status"],
+                              capture_output=True, text=True, timeout=90)
+        return float(json.loads(proc.stdout.strip().splitlines()[-1]).get("accountValue", 0))
+    except Exception:
+        return 0.0
+
+
+def _intent(tid: str, coin: str, decision: dict[str, Any], mode: str, equity: float) -> dict[str, Any]:
+    """Turn a signal decision into a cap-enforced order intent."""
+    leverage = max(1, min(MAX_LEVERAGE, int(decision.get("leverage") or MAX_LEVERAGE)))
+    stop_pct = float(decision.get("stop_pct") or 0)
+    risk_pct = RISK_PCT.get(mode, 0)
+    risk_usd = equity * risk_pct / 100.0
+    notional = max(MIN_NOTIONAL + 1, risk_usd / (stop_pct / 100.0)) if stop_pct > 0 else 0
+    return {
+        "technique": tid, "coin": coin, "side": decision["action"],
+        "leverage": leverage, "sl_pct": round(stop_pct, 3),
+        "confidence": float(decision.get("confidence") or 0),
+        "notional": round(notional, 2),
+        "reason": str(decision.get("reason") or "")[:120],
+    }
+
+
+def _worklist(adopted: list[dict[str, Any]], args: argparse.Namespace) -> list[tuple[str, str, str]]:
+    """Resolve (technique, coin, interval) pairs to evaluate this run.
+
+    Default: each technique on the market it was proven on. ``--coins`` overrides
+    to explore a technique on other markets (at ``--interval``).
+    """
+    if args.coins:
+        coins = [c.strip() for c in args.coins.split(",") if c.strip()]
+        return [(e["id"], coin, args.interval) for e in adopted for coin in coins]
+    return [(e["id"], e["coin"], e["interval"]) for e in adopted]
+
+
+def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
+    """Evaluate adopted techniques on live features; optionally execute top intent."""
+    meta = load_metabolism()
+    mode = meta.get("mode", "thrive")
+    style = load_style()
+    if not style["adopted"]:
+        return {"ok": True, "mode": mode, "intents": [], "note": "no adopted techniques"}
+    # Each adopted technique runs on its own proven (coin, interval) unless overridden.
+    worklist = _worklist(style["adopted"], args)
+    coins = sorted({coin for _, coin, _ in worklist})
+    live = get_live_features(coins)
+    cache: dict[tuple[str, str], list[dict[str, float]]] = {}
+    intents: list[dict[str, Any]] = []
+    equity = _equity_usd()
+    for tid, coin, interval in worklist:
+        key = (coin, interval)
+        if key not in cache:
+            cache[key] = get_candles(coin, interval, 60)
+        cs = cache[key]
+        if len(cs) <= WARMUP:
+            continue
+        f = features_at(cs, len(cs) - 1, coin, live.get(coin))
+        decision = call_signal(load_signal(tid), f)
+        if decision and decision["action"] != "flat" and float(decision.get("stop_pct") or 0) > 0:
+            intents.append(_intent(tid, coin, decision, mode, equity))
+    intents.sort(key=lambda x: x["confidence"], reverse=True)
+    result = {"ok": True, "mode": mode, "equity": equity, "intents": intents}
+    if args.execute and intents and mode != "hibernate" and intents[0]["notional"] >= MIN_NOTIONAL:
+        result["executed"] = _execute(intents[0])
+    elif args.execute:
+        result["executed"] = {"skipped": "hibernate, no intent, or below min notional"}
+    return result
+
+
+def _execute(intent: dict[str, Any]) -> dict[str, Any]:
+    """Place the intent through hl_perp.js — the single cap-enforced path."""
+    cmd = ["node", str(SCRIPT_DIR / "hl_perp.js"), "open",
+           "--coin", intent["coin"], "--side", intent["side"],
+           "--notional", str(intent["notional"]), "--leverage", str(intent["leverage"]),
+           "--sl-pct", str(intent["sl_pct"]), "--tp-pct", str(round(intent["sl_pct"] * 1.5, 2))]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    try:
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+    except Exception:
+        return {"ok": False, "error": proc.stderr.strip()[:200] or "execution failed"}
+
+
+SKILL_TEMPLATE = """---
+name: technique-{name}
+kind: {kind}
+author: agent {author}
+---
+
+# Technique: {name}
+
+**Edge claimed:** {claim}
+
+A self-authored Gclaw technique. `signal.py` exports `signal(features) -> decision`.
+
+## Features available
+`coin, price, ret1, ret4, ret24, vol, mom, rng` (always) and
+`funding, oi, premium` (live only — None in backtests; treat None as neutral).
+
+## Decision
+Return `{{"action": "long"|"short"|"flat", "confidence": 0..1,
+"leverage": 1..3, "stop_pct": >0, "reason": str}}`.
+
+Prove it: `forge.py prove {name}` — only out-of-sample edge graduates.
+"""
+
+SIGNAL_TEMPLATE = '''"""Self-authored technique signal. Pure function; stdlib math/statistics only."""
+
+
+def signal(f):
+    """Map a feature dict to a trade decision (or flat)."""
+    return {"action": "flat", "confidence": 0.0, "stop_pct": 2.0, "reason": "stub"}
+'''
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Gclaw technique forge")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    d = sub.add_parser("draft", help="scaffold a new technique")
+    d.add_argument("name")
+    d.add_argument("--kind", choices=["lens", "edge"], default="edge")
+    d.add_argument("--claim", default="")
+    d.add_argument("--parent", default=None)
+    d.add_argument("--force", action="store_true")
+    d.set_defaults(fn=cmd_draft)
+
+    pr = sub.add_parser("prove", help="backtest a technique and write its card")
+    pr.add_argument("id")
+    pr.add_argument("--coin", default="BTC")
+    pr.add_argument("--interval", default="1h")
+    pr.add_argument("--limit", type=int, default=1000)
+    pr.set_defaults(fn=cmd_prove)
+
+    for name, fn, helptext in [("adopt", cmd_adopt, "adopt a proven technique"),
+                               ("drop", cmd_drop, "remove from loadout"),
+                               ("show", cmd_show, "show a technique + card")]:
+        s = sub.add_parser(name, help=helptext)
+        s.add_argument("id")
+        if name == "adopt":
+            s.add_argument("--force", action="store_true")
+        s.set_defaults(fn=fn)
+
+    sub.add_parser("list", help="list techniques + loadout").set_defaults(fn=cmd_list)
+
+    r = sub.add_parser("run", help="evaluate adopted techniques on live data")
+    r.add_argument("--coins", default=None, help="override markets (default: each technique's proven market)")
+    r.add_argument("--interval", default="1h", help="interval for --coins override")
+    r.add_argument("--execute", action="store_true", help="place the top intent (within caps)")
+    r.set_defaults(fn=cmd_run)
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    print(json.dumps(args.fn(args), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/forge_data.js
+++ b/scripts/forge_data.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Market-data bridge for the technique forge (read-only, no auth).
+ *
+ * Pulls HyperLiquid perp candles and current asset contexts straight from the
+ * public info API so the Python forge can backtest and run techniques without
+ * the SDK or a signed session. Emits JSON on stdout.
+ *
+ *   node forge_data.js candles  --coin BTC --interval 1h --limit 500
+ *   node forge_data.js features --coins BTC,ETH,SOL
+ *
+ * candleSnapshot needs a time window, so --limit is converted to [from, now]
+ * using the interval; HL caps a response at ~5000 candles.
+ */
+'use strict';
+
+const INFO_URL = 'https://api.hyperliquid.xyz/info';
+
+const INTERVAL_MS = {
+  '1m': 60_000, '5m': 300_000, '15m': 900_000, '30m': 1_800_000,
+  '1h': 3_600_000, '4h': 14_400_000, '1d': 86_400_000,
+};
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) {
+      const key = argv[i].slice(2);
+      const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[(i += 1)] : 'true';
+      out[key] = val;
+    }
+  }
+  return out;
+}
+
+function die(msg) {
+  process.stdout.write(JSON.stringify({ ok: false, error: msg }) + '\n');
+  process.exit(1);
+}
+
+async function info(body) {
+  const res = await fetch(INFO_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`HL info ${res.status}`);
+  return res.json();
+}
+
+async function candles(coin, interval, limit) {
+  const step = INTERVAL_MS[interval];
+  if (!step) die(`unknown interval '${interval}'`);
+  const now = Date.now();
+  const from = now - step * (limit + 2);
+  const raw = await info({ type: 'candleSnapshot', req: { coin, interval, startTime: from, endTime: now } });
+  return (raw || []).map((k) => ({
+    t: k.t, o: Number(k.o), h: Number(k.h), l: Number(k.l), c: Number(k.c), v: Number(k.v),
+  }));
+}
+
+async function features(coins) {
+  const [meta, ctxs] = await info({ type: 'metaAndAssetCtxs' });
+  const byName = new Map();
+  meta.universe.forEach((u, i) => byName.set(u.name, ctxs[i]));
+  const out = {};
+  for (const coin of coins) {
+    const c = byName.get(coin);
+    if (!c) { out[coin] = null; continue; }
+    out[coin] = {
+      mark: Number(c.markPx),
+      oracle: Number(c.oraclePx),
+      funding: Number(c.funding),
+      openInterest: Number(c.openInterest),
+      premium: Number(c.premium),
+      prevDayPx: Number(c.prevDayPx),
+      dayNtlVlm: Number(c.dayNtlVlm),
+    };
+  }
+  return out;
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  if (cmd === 'candles') {
+    const data = await candles(args.coin || 'BTC', args.interval || '1h', Number(args.limit || 500));
+    process.stdout.write(JSON.stringify({ ok: true, coin: args.coin || 'BTC', interval: args.interval || '1h', candles: data }) + '\n');
+  } else if (cmd === 'features') {
+    const coins = String(args.coins || 'BTC,ETH,SOL').split(',').map((s) => s.trim()).filter(Boolean);
+    process.stdout.write(JSON.stringify({ ok: true, features: await features(coins) }) + '\n');
+  } else {
+    die(`unknown command '${cmd}'. Use: candles | features`);
+  }
+}
+
+main().catch((e) => die(e.message));


### PR DESCRIPTION
## The idea

Gclaw agents can survive, evolve their DNA, talk, swarm, and trade. The missing layer: **turning experience into a transferable, proven skill.** This adds the **technique forge** — an agent writes a `signal()`, proves it on real market history, and trades it within the risk caps as part of its own evolving **style**.

This is **v1 (the solo loop)**. It's built to extend into the collaborative gene pool (v2: publish / discover / critique / fork / royalties / tournaments) — the provenance and onchain anchoring are already in place.

## The loop

`scripts/forge.py` (stdlib Python) + `scripts/forge_data.js` (HyperLiquid candles/features, no auth):

| verb | what it does |
|---|---|
| `draft` | scaffold a technique dir (`technique.json`, `SKILL.md`, `signal.py`) |
| `prove` | walk-forward backtest over real candles → perf card; **graduates only on out-of-sample edge** |
| `adopt` | add a proven technique to `style.json`, pinned to its proven market |
| `run` | evaluate adopted techniques on live data; `--execute` trades the top intent |

A technique is a pure `signal(features) -> {action, confidence, leverage, stop_pct, reason}`.

## The evidence gate (why it's trustworthy, not lore)

A technique can't go live until a backtest it didn't get to tune proves edge:
- **Walk-forward** 60/40 in-sample / out-of-sample split
- **Both samples must be positive** with `n_oos >= 20` — OOS-only edge is treated as luck
- **Costs charged**, **stops simulated** on bar highs/lows
- Cards are computed by a shared harness — no self-reported performance

Demonstrated: the example `vol-momentum` **graduates on ETH 4h** (OOS n=159, expectancy +0.00018) and is **correctly refused on BTC 4h** (negative in-sample). The refusal is the point.

## Safety — full autonomy *within* caps

The technique decides the trade; the forge enforces rails it cannot widen:
- **Sandbox** — `signal.py` may import only `math`/`statistics`; `eval`/`open`/`os`/`__import__`/dunder access are rejected by an AST check before execution; wall-clock capped.
- **Caps** — leverage clamped **≤3×**, **stop mandatory**, risk-budget sizing (5% THRIVE / 2% SURVIVE), HIBERNATE blocks, $11 min — re-applied on the single `hl_perp.js` execution path.

Verified: a greedy technique asking for 50× is clamped to 3×; `import os` and `eval` are flagged by the sandbox.

## Provenance — rides the onchain identity

Every technique is stamped with the agent's ERC-8004 `agentId` (e.g. `55624` on Base) as `author`, plus optional `parent` lineage — so when techniques enter the shared gene pool in v2, reputation and royalties anchor to a verifiable onchain identity.

## Wiring

Heartbeat (`SKILL.md`) now consults adopted techniques in **step 6** (cap-checked intents as a prior) and authors/proves new ones in the growth phase (**step 8**). Full playbook + safety model in `references/forge.md`.

## Files
- `scripts/forge.py` — engine (draft/prove/adopt/run, backtest, sandbox, caps)
- `scripts/forge_data.js` — HyperLiquid candle + feature bridge
- `references/forge.md` — playbook, feature/decision contract, evidence gate, safety model, v2 roadmap
- `SKILL.md`, `CLAUDE.md` — heartbeat wiring + script index

Runtime techniques live under `$GCLAW_HOME/forge/` (state), not the repo. Lints clean (`ruff`), `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)