### PR TITLE
Earned leverage cap + stop autofund dust errors

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -18,8 +18,18 @@ No memecoins. No unlisted low-liquidity tokens. Liquidity and a legible thesis g
 
 ## Risk controls (hard limits)
 - **Max risk per trade:** 5% of current GMAC balance. In SURVIVE mode, 2%.
-- **Max leverage:** 3x. Set it explicitly in the order (`leverage`) — verified to land at exactly 3x
-  (isolated on builder dexes). Never rely on HL's 20x default; there is no separate set_leverage call.
+- **Max leverage is EARNED, gated by goodwill** (won from profitable trades). The cap rises as the
+  organism proves it can survive — start careful, earn your rope:
+  | goodwill | leverage cap |
+  |---|---|
+  | 0–49 | 3x |
+  | 50–199 | 5x |
+  | 200–499 | 10x |
+  | 500–999 | 15x |
+  | ≥1000 | 20x (max) |
+  Set leverage explicitly in the order (`leverage`); both `hl_perp.js` and the forge clamp it to the
+  earned cap automatically. Never rely on HL's 20x default; there is no separate set_leverage call.
+  At goodwill 0 you trade 3x no matter what you ask for — go earn it.
 - **Always** set TP and SL when opening a perp. No naked positions.
 - **One or two open theses at a time.** No scattering risk across many names.
 - Keep dry powder: never deploy the whole treasury; the survival buffer is sacred.

--- a/references/forge.md
+++ b/references/forge.md
@@ -92,9 +92,11 @@ optional and a technique cannot widen them:
 - **Sandbox** — `signal.py` may import only `math`/`statistics`; `eval`, `open`,
   `os`, `__import__`, dunder access, etc. are rejected by an AST check before the
   code ever runs, and execution is wall-clock capped.
-- **Caps** — leverage clamped to **≤3×**; a **stop is mandatory**; size comes
-  from the risk budget (5% equity in THRIVE, 2% in SURVIVE) divided by the stop;
-  HIBERNATE blocks execution; the **$11 HL minimum** is enforced.
+- **Caps** — leverage is **earned**: clamped to the goodwill ladder (3× at
+  goodwill 0, rising to 20× at 1000+), so a technique can never trade more rope
+  than the organism has earned; a **stop is mandatory**; size comes from the risk
+  budget (5% equity in THRIVE, 2% in SURVIVE) divided by the stop; HIBERNATE
+  blocks execution; the **$11 HL minimum** is enforced.
 - **One execution path** — `run --execute` places trades only through
   `hl_perp.js`, which re-applies every cap. A technique never touches execution
   directly.

--- a/scripts/autofund.js
+++ b/scripts/autofund.js
@@ -26,6 +26,7 @@ const ARB_RPC = process.env.ARB_RPC || 'https://arb1.arbitrum.io/rpc';
 const ARB_CHAIN = 42161;
 const ARB_USDC = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
 const GAS_RESERVE_ETH = 0.0003; // keep enough Arbitrum ETH for the swap + deposit tx
+const MIN_SWAP_ETH = 0.006; // ~$10 at current ETH; below this a swap can't clear the HL min — skip dust
 const MIN_DEPOSIT_USDC = 10; // HyperLiquid minimum
 const SLIPPAGE = 2;
 
@@ -65,8 +66,10 @@ async function main() {
   const swapEth = Math.max(0, ethBal - GAS_RESERVE_ETH);
   const summary = { ok: true, mode, arbitrumEth: ethBal, gasReserve: GAS_RESERVE_ETH, swapEth: Number(swapEth.toFixed(6)) };
 
-  if (swapEth <= 0) {
-    summary.action = 'nothing to convert (ETH at or below gas reserve)';
+  if (swapEth < MIN_SWAP_ETH) {
+    summary.action = swapEth <= 0
+      ? 'nothing to convert (ETH at or below gas reserve)'
+      : `holding ${swapEth.toFixed(6)} ETH dust (below ${MIN_SWAP_ETH} min swap — would not clear the HL deposit min)`;
     console.log(JSON.stringify(summary, null, 2));
     return;
   }

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -38,7 +38,11 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 # Risk caps (mirror dna/TRADING_STRATEGY.md — enforced, never bypassable).
-MAX_LEVERAGE = 3
+# Leverage is EARNED: the cap rises with goodwill, the metric won from profitable
+# trades. A young agent trades small and careful; it unlocks more rope as it
+# proves it can survive. Keep this ladder in sync with hl_perp.js.
+MAX_LEVERAGE = 20  # absolute ceiling at the top of the ladder
+LEVERAGE_LADDER = [(0, 3), (50, 5), (200, 10), (500, 15), (1000, 20)]
 RISK_PCT = {"thrive": 5, "survive": 2, "hibernate": 0}
 MIN_NOTIONAL = 11
 
@@ -176,6 +180,17 @@ def load_metabolism() -> dict[str, Any]:
 def agent_id() -> str:
     ident = load_metabolism().get("onchain_identity") or {}
     return str(ident.get("agentId") or "local")
+
+
+def leverage_cap(goodwill: Optional[float] = None) -> int:
+    """The agent's earned leverage ceiling, unlocked by goodwill."""
+    if goodwill is None:
+        goodwill = float(load_metabolism().get("goodwill", 0) or 0)
+    cap = LEVERAGE_LADDER[0][1]
+    for threshold, lev in LEVERAGE_LADDER:
+        if goodwill >= threshold:
+            cap = lev
+    return min(cap, MAX_LEVERAGE)
 
 
 def die(msg: str) -> None:
@@ -823,9 +838,10 @@ def _equity_usd() -> float:
         return 0.0
 
 
-def _intent(tid: str, coin: str, decision: dict[str, Any], mode: str, equity: float) -> dict[str, Any]:
-    """Turn a signal decision into a cap-enforced order intent."""
-    leverage = max(1, min(MAX_LEVERAGE, int(decision.get("leverage") or MAX_LEVERAGE)))
+def _intent(tid: str, coin: str, decision: dict[str, Any], mode: str, equity: float,
+            cap: int) -> dict[str, Any]:
+    """Turn a signal decision into a cap-enforced order intent (cap = earned ceiling)."""
+    leverage = max(1, min(cap, int(decision.get("leverage") or cap)))
     stop_pct = float(decision.get("stop_pct") or 0)
     risk_pct = RISK_PCT.get(mode, 0)
     risk_usd = equity * risk_pct / 100.0
@@ -855,9 +871,11 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
     """Evaluate adopted techniques on live features; optionally execute top intent."""
     meta = load_metabolism()
     mode = meta.get("mode", "thrive")
+    cap = leverage_cap(float(meta.get("goodwill", 0) or 0))
     style = load_style()
     if not style["adopted"]:
-        return {"ok": True, "mode": mode, "intents": [], "note": "no adopted techniques"}
+        return {"ok": True, "mode": mode, "leverage_cap": cap, "intents": [],
+                "note": "no adopted techniques"}
     # Each adopted technique runs on its own proven (coin, interval) unless overridden.
     worklist = _worklist(style["adopted"], args)
     coins = sorted({coin for _, coin, _ in worklist})
@@ -875,9 +893,9 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
         f = features_at(cs, len(cs) - 1, coin, live.get(coin))
         decision = call_signal(load_signal(tid), f)
         if decision and decision["action"] != "flat" and float(decision.get("stop_pct") or 0) > 0:
-            intents.append(_intent(tid, coin, decision, mode, equity))
+            intents.append(_intent(tid, coin, decision, mode, equity, cap))
     intents.sort(key=lambda x: x["confidence"], reverse=True)
-    result = {"ok": True, "mode": mode, "equity": equity, "intents": intents}
+    result = {"ok": True, "mode": mode, "leverage_cap": cap, "equity": equity, "intents": intents}
     if args.execute and intents and mode != "hibernate" and intents[0]["notional"] >= MIN_NOTIONAL:
         top = intents[0]
         result["executed"] = _execute(top)

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -33,8 +33,24 @@ const SDK = require(path.join(GDEX_DIR, 'dist'));
 
 const HL_CHAIN_ID = 42161; // sign in on Arbitrum for HyperLiquid
 const MIN_NOTIONAL = 11; // HyperLiquid minimum order value (USD)
-const DEFAULT_LEVERAGE = 3; // strategy cap; HL defaults to 20x cross if we don't set it
+const DEFAULT_LEVERAGE = 3; // default requested leverage; clamped to the EARNED cap below
 const SZ_DECIMALS = { BTC: 5, ETH: 4, SOL: 2 }; // fallback size precision if meta is unavailable
+
+// Leverage is EARNED: the cap rises with goodwill. Keep this ladder in sync with forge.py.
+const LEVERAGE_LADDER = [[0, 3], [50, 5], [200, 10], [500, 15], [1000, 20]];
+
+function earnedLeverageCap() {
+  try {
+    const home = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
+    const meta = JSON.parse(fs.readFileSync(path.join(home, 'metabolism.json'), 'utf8'));
+    const goodwill = Number(meta.goodwill || 0);
+    let cap = LEVERAGE_LADDER[0][1];
+    for (const [threshold, lev] of LEVERAGE_LADDER) if (goodwill >= threshold) cap = lev;
+    return cap;
+  } catch {
+    return DEFAULT_LEVERAGE; // no metabolism state → conservative base
+  }
+}
 
 // Builder/HIP-3 coins are `dex:ASSET` with a LOWERCASE dex prefix (xyz:NVDA); plain coins uppercase.
 function normalizeCoin(coin) {
@@ -197,8 +213,9 @@ async function cmdOpen(wallet, args) {
   const tpPct = Number(args['tp-pct'] || 3);
   if (!args['sl-pct'] && slPct <= 0) die('a stop-loss is required (--sl-pct)');
 
-  // Leverage is a real, settable order field now (sent top-level by the SDK).
-  const leverage = Math.max(1, Math.min(50, Math.round(Number(args.leverage || DEFAULT_LEVERAGE))));
+  // Leverage is a real, settable order field, clamped to the EARNED cap (goodwill ladder).
+  const cap = earnedLeverageCap();
+  const leverage = Math.max(1, Math.min(cap, Math.round(Number(args.leverage || DEFAULT_LEVERAGE))));
 
   const { skill, creds } = await signedSkill(wallet);
   const px = await markPriceFor(skill, coin);
@@ -222,7 +239,7 @@ async function cmdOpen(wallet, args) {
     ...creds,
   });
   if (res && res.isSuccess === false) die(`open rejected: ${JSON.stringify(res)}`);
-  return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', leverage, mark: px, size, notional: Number(notional.toFixed(2)), sl, tp };
+  return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', leverage, leverageCap: cap, mark: px, size, notional: Number(notional.toFixed(2)), sl, tp };
 }
 
 // Resolve a position's signed size from the coin's own dex (builder coins live


### PR DESCRIPTION
## Earned leverage 🎚️

Leverage is now **earned, gated by goodwill** (the metric won from profitable trades). A young agent starts careful and unlocks more rope as it proves it can survive:

| goodwill | leverage cap |
|---|---|
| 0–49 | 3× |
| 50–199 | 5× |
| 200–499 | 10× |
| 500–999 | 15× |
| ≥1000 | **20× (max)** |

Enforced on **both** execution paths — `hl_perp.js` (direct) and the forge's `_intent` (technique-driven) — reading live goodwill from `metabolism.json`. Asking for more than you've earned simply lands at your cap. Verified: a greedy 20× technique at goodwill 0 is clamped to 3×; the ladder steps correctly at each threshold.

## Troubleshooting fix: autofund dust spam

The hourly heartbeat was logging a GDEX error every run — autofund kept trying to swap **0.0007 ETH of dust** (~$1, below the $10 HL deposit minimum), which the swap API rejected with `missing params`. It now holds anything below `MIN_SWAP_ETH` (~$10 worth) instead of spamming failing swaps. Clean `ok:true` now.

## Deployment status (checked)

- Installed skill `~/.claude/skills/gclaw` is a **symlink to the repo** → the running agent always has latest code (forge + these fixes) automatically.
- Hourly cron is **live and firing** (heartbeats 13:00/14:00/15:00 OK); the agent signs in via MCP, reads HL state, and settles PnL each hour.
- The forge runs cleanly in the cron's restricted environment.

## Files
- `scripts/forge.py`, `scripts/hl_perp.js` — earned leverage ladder + enforcement
- `scripts/autofund.js` — dust-swap floor
- `dna/TRADING_STRATEGY.md`, `references/forge.md` — earned-leverage docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)