### PR TITLE
Fix: autosettle uses uv run, not bare python3

### DIFF
--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -58,9 +58,13 @@ function selectNew(fills, cursor) {
 }
 
 function settle(pnl, note) {
-  execFileSync('python3', [path.join(__dirname, 'metabolism.py'), 'settle', '--pnl', String(pnl), '--note', note], {
+  // Use `uv run --no-project python3` — bare python3 is blocked on this box and is
+  // not guaranteed on PATH. This is the only path that books PnL and awards goodwill,
+  // so it must not fail silently; surface stderr if metabolism.py errors.
+  execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'metabolism.py'),
+    'settle', '--pnl', String(pnl), '--note', note], {
     env: { ...process.env, GCLAW_HOME },
-    stdio: 'ignore',
+    stdio: ['ignore', 'ignore', 'inherit'],
   });
 }
 


### PR DESCRIPTION
autosettle.js spawned bare `python3` to run `metabolism.py settle` — the only path that books PnL and **awards goodwill** (which gates earned leverage). Bare python3 is blocked on this box and not guaranteed on PATH, so a settle could fail silently → unbooked PnL and a frozen leverage ladder. Now uses `uv run --no-project python3` and surfaces stderr. Verified the uv→python3→metabolism path runs in the cron environment. Closes assune-4v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)