### PR TITLE
Fix funding: managed swap signer + unified-balance capital gauge

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -74,6 +74,11 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
    `uv run --no-project python3 scripts/telepathy.py inbox` (act on fresh trade_signal/warning).
    Read live exposure via `mcp__gdex__get_hl_clearinghouse_state {userAddress: <managed>}`,
    `get_hl_spot_state`, and `get_hl_open_orders` — the source of truth for positions and free capital.
+   **Capital gauge:** HL keeps ONE unified USDC balance. Free buying power for a new
+   trade is `node scripts/hl_perp.js status` → `buyingPower` (spot USDC `total − hold`),
+   NOT perp `withdrawable`/`accountValue` (those only show margin already committed and
+   read ~$0 even when the account is fully funded). Deposits land in spot; HL pledges
+   margin from it automatically when a perp is opened — there is no spot→perp transfer.
 4. **Reconcile closes (auto).** Run `node scripts/autosettle.js run` — it books realized PnL from any
    closes (TP/SL or manual) by reading HL fills, netting `closedPnl − fee`, and calling `metabolism.py
    settle` exactly once per close (cursor-deduped; safe if the cron already ran it). Don't settle trade

--- a/scripts/autofund.js
+++ b/scripts/autofund.js
@@ -58,6 +58,32 @@ async function signIn(skill, wallet) {
   return { apiKey, walletAddress: wallet.control, sessionPrivateKey: kp.sessionPrivateKey };
 }
 
+// Managed-custody EVM swaps require a session-key-signed computedData posted to
+// /v1/purchase_v2 — the plain buyToken() flow is rejected ("missing params").
+async function swapEthToUsdc(skill, creds, swapEth) {
+  const amountWei = ethers.parseEther(swapEth.toFixed(9)).toString();
+  const trade = SDK.buildGdexManagedTradeComputedData({
+    apiKey: creds.apiKey,
+    action: 'purchase',
+    userId: creds.walletAddress,
+    tokenAddress: ARB_USDC,
+    amount: amountWei,
+    nonce: String(Date.now()),
+    sessionPrivateKey: creds.sessionPrivateKey,
+  });
+  const sub = await skill.submitManagedPurchase({ computedData: trade.computedData, chainId: ARB_CHAIN, slippage: SLIPPAGE });
+  const requestId = sub.requestId || sub.jobId || sub?.data?.requestId;
+  if (!requestId) throw new Error(`swap not accepted: ${JSON.stringify(sub)}`);
+  for (let i = 0; i < 18; i += 1) {
+    await sleep(8000);
+    const st = await skill.getManagedTradeStatus(requestId);
+    const state = st.status || 'unknown';
+    if (['completed', 'confirmed', 'success'].includes(state)) return st.hash || st.txHash || 'confirmed';
+    if (state === 'failed') throw new Error(`swap failed: ${JSON.stringify(st)}`);
+  }
+  throw new Error('swap timed out waiting for confirmation');
+}
+
 async function main() {
   const mode = process.argv[2] || 'plan';
   const wallet = loadWallet();
@@ -84,12 +110,10 @@ async function main() {
   const creds = await signIn(skill, wallet);
 
   const before = await usdcBalance(provider, wallet.managed);
-  const swap = await skill.buyToken({ chain: ARB_CHAIN, tokenAddress: ARB_USDC, amount: String(swapEth), slippage: SLIPPAGE, ...creds });
-  if (swap && swap.isSuccess === false) throw new Error(`swap rejected: ${JSON.stringify(swap)}`);
-  summary.swap = 'submitted';
+  summary.swap = await swapEthToUsdc(skill, creds, swapEth);
 
   let after = before;
-  for (let i = 0; i < 12 && after <= before + 0.01; i += 1) {
+  for (let i = 0; i < 6 && after <= before + 0.01; i += 1) {
     await sleep(5000);
     after = await usdcBalance(provider, wallet.managed);
   }

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -828,24 +828,36 @@ def cmd_critique(args: argparse.Namespace) -> dict[str, Any]:
     return {"ok": True, "id": args.id, "verdict": verdict}
 
 
-def _equity_usd() -> float:
-    """Read HL account value via hl_perp.js (best effort; 0 on failure)."""
+def _account() -> dict[str, float]:
+    """Read HL equity + free buying power via hl_perp.js (best effort).
+
+    HL keeps one unified USDC balance; `equity` is the whole account and
+    `buyingPower` is the slice not already pledged as margin. Perp
+    `withdrawable`/`accountValue` only reflect committed margin, so neither is
+    the capital available for a new trade.
+    """
     try:
         proc = subprocess.run(["node", str(SCRIPT_DIR / "hl_perp.js"), "status"],
                               capture_output=True, text=True, timeout=90)
-        return float(json.loads(proc.stdout.strip().splitlines()[-1]).get("accountValue", 0))
+        st = json.loads(proc.stdout.strip().splitlines()[-1])
+        equity = float(st.get("equity") or st.get("spotUsdc") or st.get("accountValue") or 0)
+        return {"equity": equity, "buying_power": float(st.get("buyingPower") or equity)}
     except Exception:
-        return 0.0
+        return {"equity": 0.0, "buying_power": 0.0}
 
 
 def _intent(tid: str, coin: str, decision: dict[str, Any], mode: str, equity: float,
-            cap: int) -> dict[str, Any]:
+            cap: int, buying_power: float) -> dict[str, Any]:
     """Turn a signal decision into a cap-enforced order intent (cap = earned ceiling)."""
     leverage = max(1, min(cap, int(decision.get("leverage") or cap)))
     stop_pct = float(decision.get("stop_pct") or 0)
     risk_pct = RISK_PCT.get(mode, 0)
     risk_usd = equity * risk_pct / 100.0
     notional = max(MIN_NOTIONAL + 1, risk_usd / (stop_pct / 100.0)) if stop_pct > 0 else 0
+    # Margin = notional / leverage must fit the free collateral (95% headroom for fees).
+    max_notional = max(0.0, buying_power * 0.95) * leverage
+    if notional > max_notional:
+        notional = max_notional if max_notional >= MIN_NOTIONAL else 0
     return {
         "technique": tid, "coin": coin, "side": decision["action"],
         "leverage": leverage, "sl_pct": round(stop_pct, 3),
@@ -882,7 +894,8 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
     live = get_live_features(coins)
     cache: dict[tuple[str, str], list[dict[str, float]]] = {}
     intents: list[dict[str, Any]] = []
-    equity = _equity_usd()
+    acct = _account()
+    equity, buying_power = acct["equity"], acct["buying_power"]
     for tid, coin, interval in worklist:
         key = (coin, interval)
         if key not in cache:
@@ -893,9 +906,10 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
         f = features_at(cs, len(cs) - 1, coin, live.get(coin))
         decision = call_signal(load_signal(tid), f)
         if decision and decision["action"] != "flat" and float(decision.get("stop_pct") or 0) > 0:
-            intents.append(_intent(tid, coin, decision, mode, equity, cap))
+            intents.append(_intent(tid, coin, decision, mode, equity, cap, buying_power))
     intents.sort(key=lambda x: x["confidence"], reverse=True)
-    result = {"ok": True, "mode": mode, "leverage_cap": cap, "equity": equity, "intents": intents}
+    result = {"ok": True, "mode": mode, "leverage_cap": cap, "equity": equity,
+              "buying_power": round(buying_power, 2), "intents": intents}
     if args.execute and intents and mode != "hibernate" and intents[0]["notional"] >= MIN_NOTIONAL:
         top = intents[0]
         result["executed"] = _execute(top)

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -194,11 +194,20 @@ async function cmdStatus(wallet) {
   const spot = spotR.status === 'fulfilled' ? spotR.value : { balances: [] };
   const orders = ordersR.status === 'fulfilled' ? ordersR.value : [];
   const usdc = (spot.balances || []).find((b) => b.coin === 'USDC');
+  const spotTotal = usdc ? Number(usdc.total) : 0;
+  const spotHold = usdc ? Number(usdc.hold) : 0;
+  const unrealized = (full.positions || []).reduce((s, p) => s + Number(p.unrealizedPnl || 0), 0);
   return {
     ok: true,
     managed: wallet.managed,
-    spotUsdc: usdc ? Number(usdc.total) : 0,
-    accountValue: full.accountValue, // total tradable equity across default + builder dexes
+    // HL uses ONE unified USDC balance: spot `total` is the whole account, `hold`
+    // is the slice already pledged as perp margin. Free collateral for NEW perps
+    // is total - hold — perp `withdrawable` reads ~0 and is NOT the buying power.
+    spotUsdc: spotTotal,
+    spotHold,
+    buyingPower: Math.max(0, spotTotal - spotHold),
+    equity: spotTotal + unrealized, // true account equity for risk sizing
+    accountValue: full.accountValue, // perp-committed margin only (legacy field)
     withdrawable: full.withdrawable,
     positions: full.positions, // includes builder-dex (xyz:*) positions
     openOrders: (orders || []).map((o) => ({ coin: o.coin, px: Number(o.limitPx), sz: Number(o.sz), reduceOnly: !!o.reduceOnly })),


### PR DESCRIPTION
## What

Two linked fixes to the live trading agent's funding path, found while sweeping ~$200 of ETH into the agent.

### 1. autofund sweeper used the wrong swap call
`buyToken()` posts plain params; the GDEX backend rejects managed-custody EVM swaps with `missing params` (code 101). Switched to `submitManagedPurchase()` with a session-key-signed `computedData` (the proven `/v1/purchase_v2` flow). Amount is native ETH in wei. Verified live: 0.03 ETH → 52.2 USDC, then the full sweep → 199 USDC deposited to HL.

### 2. agent gauged capital from the wrong balance
HyperLiquid keeps **one unified USDC balance**: deposits land in spot, and HL pledges perp margin from it automatically on order open — there is no spot→perp transfer (GDEX returns `Swapping SPOT to PERP is not supported`). The agent read perp `withdrawable`/`accountValue` (~$0 even when fully funded), so for 26 heartbeats it believed it was broke and never traded.

- `hl_perp.js status` now reports `buyingPower` (spot `total − hold`) and `equity`.
- `forge.py` sizes risk against `equity` and clamps notional to free `buyingPower`.
- `SKILL.md` documents the unified-balance capital gauge.

Verified end-to-end: status now shows `buyingPower 206.70`; the forge produces a funded, margin-clamped intent (vol-momentum ETH long, 3x, $315 notional) where before it produced nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)