### PR TITLE
Make buyingPower the heartbeat's authoritative free-capital read

### DIFF
--- a/dna/HEARTBEAT.md
+++ b/dna/HEARTBEAT.md
@@ -9,10 +9,14 @@ the family only when balance and edge justify it.
    - SURVIVE → preservation behavior: smallest sizing, defined-risk outcome tickets,
      prefer closing risk and accumulating GMAC. Cut discovery cost.
    - THRIVE → normal operation.
-2. **Manage open risk** before anything else: `get_perp_positions`, `get_hl_clearinghouse_state`.
-   Move stops to break-even on winners; honor stops on losers.
+2. **Manage open risk & read free capital** before anything else: `get_perp_positions`,
+   `get_hl_clearinghouse_state`. Move stops to break-even on winners; honor stops on losers.
+   **Free capital = `node scripts/hl_perp.js status` → `buyingPower`** (HL keeps ONE unified
+   USDC balance; buyingPower = spot `total − hold`). The MCP clearinghouse `accountValue` /
+   `withdrawable` is only margin already committed — it reads ~$0 even when fully funded, so
+   NEVER treat it as free capital. If `buyingPower` ≥ the min notional, you have money to trade.
 3. **Read the tape**: `get_hl_meta_and_asset_ctxs` (mark, funding, OI). For events: `hl_outcomes`.
-4. **Act** only on a clear thesis, sized by the risk limit, always with TP/SL. At most one or two moves.
+4. **Act** only on a clear thesis, sized by the risk limit and free `buyingPower`, always with TP/SL. At most one or two moves.
 5. **Settle** realized PnL into the metabolism. Charge a discovery cost if the cycle did heavy intel.
 6. **Evolve** if a goodwill threshold is newly crossed.
 7. **Chatter** one short line to the family in your own voice (see your persona) — this is the show people watch.


### PR DESCRIPTION
The heartbeat LLM occasionally narrated 'no free capital' off the MCP clearinghouse `accountValue`/`withdrawable` (~$0 = committed margin), even with $176 of real buying power. The deterministic forge path already used the correct number, so it never blocked a trade — but the reasoning was inconsistent. This makes the DNA heartbeat procedure state that free capital is `hl_perp.js status` → `buyingPower` (unified spot total − hold), and that the clearinghouse fields are not free capital. Runtime DNA copy updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)