### PR TITLE
Scan the full market universe each heartbeat (incl. stock perps)

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -16,6 +16,12 @@ GMAC with real realized profit, then grow it without ever risking extinction.
 
 No memecoins. No unlisted low-liquidity tokens. Liquidity and a legible thesis gate every name.
 
+The technique forge scans this whole universe every heartbeat — majors plus the deepest
+`xyz` stock/commodity perps (SpaceX `xyz:SPCX`, `xyz:NVDA`, `xyz:TSLA`, `xyz:AAPL`, gold, …).
+It auto-trades a technique only on the market it was *proven* on; signals on other markets are
+surfaced as **exploration** — act on the strongest with judgment, or draft+prove a technique
+there to earn the right to auto-trade it. Don't tunnel on BTC/ETH/SOL: stocks move too.
+
 ## Risk controls (hard limits)
 - **Max risk per trade:** 5% of current GMAC balance. In SURVIVE mode, 2%.
 - **Max leverage is EARNED, gated by goodwill** (won from profitable trades). The cap rises as the

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -46,6 +46,16 @@ LEVERAGE_LADDER = [(0, 3), (50, 5), (200, 10), (500, 15), (1000, 20)]
 RISK_PCT = {"thrive": 5, "survive": 2, "hibernate": 0}
 MIN_NOTIONAL = 11
 
+# Default markets each adopted technique is scanned across every run: majors on
+# the default dex plus the deepest HIP-3 stock/commodity perps on the `xyz`
+# builder dex (USDC-collateralized, 24h). A technique auto-executes only on the
+# market it was proven on; signals on the rest are surfaced as exploration for
+# the heartbeat's judgment (and as candidates to prove next). Override --coins.
+SCAN_UNIVERSE = (
+    "BTC", "ETH", "SOL",
+    "xyz:NVDA", "xyz:TSLA", "xyz:SPCX", "xyz:AAPL", "xyz:AMZN", "xyz:GOLD",
+)
+
 # Evidence gate.
 MIN_OOS_SAMPLE = 20
 IS_FRACTION = 0.6
@@ -876,7 +886,10 @@ def _worklist(adopted: list[dict[str, Any]], args: argparse.Namespace) -> list[t
     if args.coins:
         coins = [c.strip() for c in args.coins.split(",") if c.strip()]
         return [(e["id"], coin, args.interval) for e in adopted for coin in coins]
-    return [(e["id"], e["coin"], e["interval"]) for e in adopted]
+    # Scan each technique across its proven market first, then the wider universe.
+    return [(e["id"], coin, e["interval"])
+            for e in adopted
+            for coin in dict.fromkeys([e["coin"], *SCAN_UNIVERSE])]
 
 
 def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
@@ -890,6 +903,7 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
                 "note": "no adopted techniques"}
     # Each adopted technique runs on its own proven (coin, interval) unless overridden.
     worklist = _worklist(style["adopted"], args)
+    proven_coin = {e["id"]: e["coin"] for e in style["adopted"]}
     coins = sorted({coin for _, coin, _ in worklist})
     live = get_live_features(coins)
     cache: dict[tuple[str, str], list[dict[str, float]]] = {}
@@ -906,12 +920,17 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
         f = features_at(cs, len(cs) - 1, coin, live.get(coin))
         decision = call_signal(load_signal(tid), f)
         if decision and decision["action"] != "flat" and float(decision.get("stop_pct") or 0) > 0:
-            intents.append(_intent(tid, coin, decision, mode, equity, cap, buying_power))
+            intent = _intent(tid, coin, decision, mode, equity, cap, buying_power)
+            intent["proven"] = coin == proven_coin.get(tid)
+            intents.append(intent)
     intents.sort(key=lambda x: x["confidence"], reverse=True)
     result = {"ok": True, "mode": mode, "leverage_cap": cap, "equity": equity,
               "buying_power": round(buying_power, 2), "intents": intents}
-    if args.execute and intents and mode != "hibernate" and intents[0]["notional"] >= MIN_NOTIONAL:
-        top = intents[0]
+    # Auto-execute only a signal on its proven market; cross-market signals are
+    # surfaced as exploration for the heartbeat to act on (or prove next).
+    proven = [i for i in intents if i["proven"] and i["notional"] >= MIN_NOTIONAL]
+    if args.execute and proven and mode != "hibernate":
+        top = proven[0]
         result["executed"] = _execute(top)
         if result["executed"].get("ok"):
             ref, _ = royalty_ref(load_technique(top["technique"]))
@@ -920,7 +939,7 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
             save_pending(pending)
             result["attribution"] = {"coin": top["coin"], "credit_to": ref}
     elif args.execute:
-        result["executed"] = {"skipped": "hibernate, no intent, or below min notional"}
+        result["executed"] = {"skipped": "no proven-market signal (exploration intents not auto-traded)"}
     return result
 
 

--- a/scripts/forge_data.js
+++ b/scripts/forge_data.js
@@ -59,10 +59,26 @@ async function candles(coin, interval, limit) {
   }));
 }
 
-async function features(coins) {
-  const [meta, ctxs] = await info({ type: 'metaAndAssetCtxs' });
+// Coins are bare on the default dex (BTC) and dex-prefixed on builder dexes
+// (xyz:SPCX). Builder-dex contexts live under a per-dex metaAndAssetCtxs query,
+// so fetch the default plus every referenced dex and merge by name.
+async function loadContexts(coins) {
+  const dexes = new Set(['']);
+  for (const coin of coins) {
+    const i = coin.indexOf(':');
+    if (i !== -1) dexes.add(coin.slice(0, i));
+  }
   const byName = new Map();
-  meta.universe.forEach((u, i) => byName.set(u.name, ctxs[i]));
+  for (const dex of dexes) {
+    const body = dex ? { type: 'metaAndAssetCtxs', dex } : { type: 'metaAndAssetCtxs' };
+    const [meta, ctxs] = await info(body);
+    meta.universe.forEach((u, i) => byName.set(u.name, ctxs[i]));
+  }
+  return byName;
+}
+
+async function features(coins) {
+  const byName = await loadContexts(coins);
   const out = {};
   for (const coin of coins) {
     const c = byName.get(coin);


### PR DESCRIPTION
## Problem
The agent was only ever looking at BTC/ETH/SOL — even though it can trade the deep HIP-3 stock/commodity perps (SpaceX \`xyz:SPCX\`, \`xyz:NVDA\`, \`xyz:TSLA\`, \`xyz:AAPL\`, gold…). Two causes:
1. The forge evaluated each technique only on its single *proven* market (ETH).
2. \`forge_data.js features()\` returned \`null\` for \`xyz:*\` — it only read the default-dex \`metaAndAssetCtxs\`.
3. The runtime DNA was a stale "majors only" copy that didn't even list the stock perps.

## Fix
- **forge_data.js**: \`features()\` now fetches builder-dex contexts via a per-dex \`metaAndAssetCtxs\` query and merges (SPCX/NVDA/etc. now return real mark/funding/OI/volume).
- **forge.py**: a default \`SCAN_UNIVERSE\` (majors + deepest \`xyz\` perps) is scanned every run. Each intent is tagged \`proven\`; **auto-execute fires only on a technique's proven market**, while cross-market signals are surfaced as exploration for the heartbeat to act on with judgment (or to prove next). \`--coins\` still overrides.
- **DNA**: synced the runtime \`TRADING_STRATEGY.md\` to the repo (which lists the stock perps) and noted the universe scan.

## Verified live
- \`features --coins BTC,xyz:SPCX,xyz:NVDA\` → real data (SPCX \$173.84, \$849M daily volume).
- \`forge.py run\` now surfaces stock-perp signals (e.g. \`xyz:NVDA long\`, \`xyz:AAPL long\`) tagged \`proven=False\`.
- \`forge.py run --execute\` with no proven-market signal **skips auto-trade** ("exploration intents not auto-traded") — visibility without recklessness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)