### PR TITLE
Automate the family roster + leaderboard on the dashboard

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -260,6 +260,70 @@ def techniques_html() -> str:
     return f'<ul class="events">{"".join(items)}</ul>'
 
 
+def refresh_roster(h: Path) -> None:
+    """Best-effort: cache the onchain family roster (peers.js) for the page."""
+    try:
+        proc = subprocess.run(["node", str(SCRIPT_DIR / "peers.js")],
+                              capture_output=True, text=True, timeout=60)
+        data = json.loads(proc.stdout.strip())
+        if data.get("ok"):
+            (h / "peers_roster.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except (OSError, ValueError, subprocess.SubprocessError):
+        pass  # keep the last good cache; the page renders offline regardless
+
+
+def roster_html(h: Path) -> str:
+    data = load_json(h / "peers_roster.json", {})
+    roster = data.get("roster", [])
+    if not roster:
+        return '<p class="muted">No peers discovered yet — scanning the Base registry.</p>'
+    rows = []
+    for a in roster:
+        you = ' <span class="tag">you</span>' if a.get("self") else ""
+        avatar = ' 🖼' if a.get("image") else ""
+        scan = f'https://basescan.org/nft/{data.get("registry", "")}/{a["id"]}'
+        rows.append(
+            f'<li><a href="{scan}" target="_blank">#{a["id"]}</a> '
+            f'<b>{a.get("name") or "?"}</b>{avatar}{you} '
+            f'<span class="muted">{(a.get("owner") or "?")[:10]}…</span></li>')
+    return f'<ul class="family">{"".join(rows)}</ul>'
+
+
+def refresh_leaderboard(h: Path) -> None:
+    """Best-effort: pull peer stats and recompute the family leaderboard."""
+    try:
+        subprocess.run(["node", str(SCRIPT_DIR / "stats.js"), "fetch"],
+                       capture_output=True, text=True, timeout=40)
+        proc = subprocess.run(["node", str(SCRIPT_DIR / "stats.js"), "leaderboard"],
+                              capture_output=True, text=True, timeout=20)
+        data = json.loads(proc.stdout.strip())
+        if data.get("ok"):
+            (h / "leaderboard.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except (OSError, ValueError, subprocess.SubprocessError):
+        pass
+
+
+def leaderboard_html(h: Path) -> str:
+    data = load_json(h / "leaderboard.json", {})
+    ranked = data.get("ranked", [])
+    pending = data.get("pending", [])
+    if not ranked and not pending:
+        return '<p class="muted">No published stats yet — agents publish each heartbeat.</p>'
+    rows = []
+    for e in ranked:
+        you = ' <span class="tag">you</span>' if e.get("self") else ""
+        rows.append(
+            f'<tr><td>{e.get("rank")}</td><td><b>{e.get("name") or "?"}</b>{you}</td>'
+            f'<td>{e.get("goodwill", 0)}</td><td>{e.get("gmac", 0)}</td>'
+            f'<td>${e.get("equityUsd", 0)}</td></tr>')
+    for e in pending:
+        you = ' <span class="tag">you</span>' if e.get("self") else ""
+        rows.append(f'<tr><td>·</td><td>{e.get("name") or "?"}{you}</td>'
+                    f'<td colspan="3" class="muted">awaiting published stats</td></tr>')
+    return ('<table class="lb"><tr><th>#</th><th>agent</th><th>goodwill</th>'
+            f'<th>GMAC</th><th>equity</th></tr>{"".join(rows)}</table>')
+
+
 def render_html(state: dict[str, Any], identity: str, journal: list, messages: list) -> str:
     name = "Gclaw"
     g = genome(name, state.get("born_at", "genesis"))
@@ -290,6 +354,8 @@ def render_html(state: dict[str, Any], identity: str, journal: list, messages: l
         leverage=leverage_html(state),
         techniques=techniques_html(),
         positions=positions_html(home()),
+        roster=roster_html(home()),
+        leaderboard=leaderboard_html(home()),
         recodes=state.get("recodes", 0),
         children=len(state.get("children", [])),
         generated=datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -303,6 +369,10 @@ def cmd_render(args: argparse.Namespace) -> None:
         raise SystemExit(f"No metabolism state at {h}. Run metabolism.py init first.")
     if not getattr(args, "no_live", False):
         refresh_positions(h)
+        refresh_roster(h)
+        subprocess.run(["node", str(SCRIPT_DIR / "stats.js"), "publish"],
+                       capture_output=True, text=True, timeout=80)
+        refresh_leaderboard(h)
     journal = read_jsonl(h / "journal.jsonl")
     messages = read_jsonl(h / "telepathy" / "bus.jsonl")
     identity = (h / "dna" / "IDENTITY.md").read_text(encoding="utf-8") if (h / "dna" / "IDENTITY.md").exists() else ""
@@ -370,6 +440,10 @@ ul{{list-style:none;margin:0;padding:0}}.family li,.events li{{padding:7px 0;bor
   <div class="grid2" style="margin-top:18px">
     <div class="card decent"><h2>📈 Live positions · HyperLiquid</h2>{positions}</div>
     <div class="card decent"><h2>🧬 Techniques · forge loadout</h2>{techniques}</div>
+  </div>
+  <div class="grid2" style="margin-top:18px">
+    <div class="card decent"><h2>👥 Family roster · onchain (Base)</h2>{roster}</div>
+    <div class="card decent"><h2>🏆 Leaderboard</h2>{leaderboard}</div>
   </div>
   <div class="grid2" style="margin-top:18px">
     <div class="card"><h2>Life events</h2>{events}</div>

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Performance publishing + cross-agent leaderboard for the gclaw family.
+ *
+ * Each agent publishes a tiny stats manifest (goodwill, GMAC, equity, techniques)
+ * so the family can rank itself. Manifests are pinned to IPFS when a free pinning
+ * token is configured; the CID is the portable, decentralized pointer. Without a
+ * token it still works locally (and for any peer manifest already fetched).
+ *
+ *   node stats.js publish              # build self manifest, pin to IPFS if token set
+ *   node stats.js fetch                # pull peers' manifests by known CID
+ *   node stats.js leaderboard          # rank self + peers by score
+ *
+ * Pinning: set PINATA_JWT (free tier) — that's the only external dependency.
+ * Peer CIDs live in $GCLAW_HOME/peers.json (statsCids), set via
+ *   node peers.js --add <id>   then record the CID the peer shares.
+ * Env: GCLAW_HOME, BASE_RPC, PINATA_JWT.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
+const STATS_DIR = path.join(GCLAW_HOME, 'stats');
+const PEERS_PATH = path.join(GCLAW_HOME, 'peers.json');
+const SKILL_DIR = path.join(os.homedir(), '.claude', 'skills', 'gclaw', 'scripts');
+const GATEWAY = process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
+
+const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+
+function nodeRun(script, args) {
+  const { execFileSync } = require('node:child_process');
+  try {
+    const out = execFileSync('node', [path.join(SKILL_DIR, script), ...args], { encoding: 'utf8', timeout: 70000 });
+    return JSON.parse(out.trim().split('\n').pop());
+  } catch { return null; }
+}
+
+function buildManifest() {
+  const meta = readJson(path.join(GCLAW_HOME, 'metabolism.json'), {});
+  const id = Number(meta.onchain_identity?.agentId);
+  const roster = readJson(path.join(GCLAW_HOME, 'peers_roster.json'), { roster: [] });
+  const me = (roster.roster || []).find((a) => a.id === id) || {};
+  const status = nodeRun('hl_perp.js', ['status']) || {};
+  const loadout = readJson(path.join(GCLAW_HOME, 'forge', 'style.json'), {});
+  const techniques = (loadout.adopted || []).map((a) => `${a.id}@${a.coin}`);
+  return {
+    agentId: id,
+    name: me.name || meta.onchain_identity?.name || 'Gclaw',
+    owner: me.owner || null,
+    mode: meta.mode || 'unknown',
+    gmac: round(meta.gmac_balance),
+    goodwill: meta.goodwill || 0,
+    heartbeats: meta.heartbeats || 0,
+    equityUsd: round(status.equity),
+    techniques,
+    score: (meta.goodwill || 0) * 1000 + (meta.gmac_balance || 0),
+    updatedAt: new Date().toISOString(),
+    schema: 1,
+  };
+}
+
+const round = (n) => (Number.isFinite(Number(n)) ? Math.round(Number(n) * 100) / 100 : 0);
+
+async function pinToIpfs(manifest) {
+  const jwt = process.env.PINATA_JWT;
+  if (!jwt) return null;
+  const res = await fetch('https://api.pinata.cloud/pinning/pinJSONToIPFS', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${jwt}` },
+    body: JSON.stringify({ pinataContent: manifest, pinataMetadata: { name: `gclaw-${manifest.agentId}` } }),
+  });
+  if (!res.ok) throw new Error(`pin failed: ${res.status} ${(await res.text()).slice(0, 120)}`);
+  return (await res.json()).IpfsHash;
+}
+
+async function cmdPublish() {
+  fs.mkdirSync(STATS_DIR, { recursive: true });
+  const manifest = buildManifest();
+  fs.writeFileSync(path.join(STATS_DIR, `${manifest.agentId}.json`), JSON.stringify(manifest, null, 2));
+  let cid = null;
+  try { cid = await pinToIpfs(manifest); } catch (e) { return { ok: true, manifest, cid: null, pin_error: e.message }; }
+  if (cid) {
+    const peers = readJson(PEERS_PATH, { ids: [] });
+    peers.statsCids = peers.statsCids || {};
+    peers.statsCids[manifest.agentId] = cid;
+    fs.writeFileSync(PEERS_PATH, JSON.stringify(peers, null, 2) + '\n');
+  }
+  return { ok: true, manifest, cid, gateway: cid ? GATEWAY + cid : null };
+}
+
+async function cmdFetch() {
+  fs.mkdirSync(STATS_DIR, { recursive: true });
+  const peers = readJson(PEERS_PATH, {});
+  const cids = peers.statsCids || {};
+  const pulled = [];
+  for (const [id, cid] of Object.entries(cids)) {
+    try {
+      const res = await fetch(GATEWAY + cid, { signal: AbortSignal.timeout(15000) });
+      if (!res.ok) continue;
+      const m = await res.json();
+      fs.writeFileSync(path.join(STATS_DIR, `${id}.json`), JSON.stringify(m, null, 2));
+      pulled.push(Number(id));
+    } catch { /* skip unreachable */ }
+  }
+  return { ok: true, pulled };
+}
+
+function cmdLeaderboard() {
+  const roster = readJson(path.join(GCLAW_HOME, 'peers_roster.json'), { roster: [] }).roster || [];
+  const selfId = Number(readJson(path.join(GCLAW_HOME, 'metabolism.json'), {}).onchain_identity?.agentId);
+  const ranked = [];
+  const pending = [];
+  for (const a of roster) {
+    const m = readJson(path.join(STATS_DIR, `${a.id}.json`), null);
+    if (m) ranked.push({ ...m, self: a.id === selfId });
+    else pending.push({ agentId: a.id, name: a.name, self: a.id === selfId });
+  }
+  ranked.sort((x, y) => y.score - x.score);
+  ranked.forEach((e, i) => { e.rank = i + 1; });
+  return { ok: true, ranked, pending, updatedAt: new Date().toISOString() };
+}
+
+async function main() {
+  const cmd = process.argv[2] || 'leaderboard';
+  let out;
+  if (cmd === 'publish') out = await cmdPublish();
+  else if (cmd === 'fetch') out = await cmdFetch();
+  else if (cmd === 'leaderboard') out = cmdLeaderboard();
+  else out = { ok: false, error: `unknown command '${cmd}'. Use: publish | fetch | leaderboard` };
+  process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+}
+
+main().catch((e) => { process.stdout.write(JSON.stringify({ ok: false, error: e.message }) + '\n'); process.exit(1); });


### PR DESCRIPTION
Builds on onchain peer discovery (#54). The dashboard render (run every heartbeat) now auto-refreshes the **onchain roster**, **publishes the agent's stats manifest**, and recomputes the **family leaderboard**.

- `stats.js` — tiny stats manifest (goodwill/GMAC/equity/techniques), optional IPFS pin (`PINATA_JWT` free tier), peer fetch by CID, rank by score.
- `dashboard.py` — roster + leaderboard panels, auto-refresh. Fixed parsers to read full pretty-printed JSON.

Verified live: roster shows #55624 + #55671; leaderboard ranks Zephlith #1, Blaq Ceaser G shown as awaiting published stats.

Cross-machine peer ranking needs a free pin token on both agents + CID exchange — next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)