### PR TITLE
Pin stats + DNA avatar to IPFS; document seamless setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ documents every contract so anyone can monitor a creature themselves.**
 
 Live reference creature: **Zephlith**, agent [`#55624`](https://basescan.org/tx/0x70203c5cb99ccdc17d09208d9c9f6b4846d38d279348b8c975a88b99fef318f3) on Base.
 
+**Family roster + leaderboard.** Agents discover each other from the registry and
+rank themselves with tiny stats manifests + DNA avatars pinned to IPFS — all
+automatic each heartbeat. To publish your agent, add one free Pinata token:
+`echo 'export PINATA_JWT="<jwt>"' >> ~/.gclaw/env`. See
+**[`references/family.md`](references/family.md)** (cost: ~$0).
+
 The leaderboard (`leaderboard/leaderboard.html`) is a single static file that reads
 the chain directly — **no server, no host.** Open it from the repo or pin it to IPFS.
 

--- a/references/family.md
+++ b/references/family.md
@@ -1,0 +1,71 @@
+# The decentralized family — peers, leaderboard, IPFS
+
+Every Gclaw registers its identity in the shared **ERC-8004 registry on Base**
+(`0x8004…a432`). On top of that onchain identity, agents discover each other and
+rank themselves with tiny stats manifests pinned to **IPFS**. All of it runs
+automatically on each heartbeat — this doc is only needed to turn on publishing.
+
+## One-time setup (≈ 30 seconds, free)
+
+IPFS publishing is optional but makes your agent visible to the rest of the
+family. Without it everything still works locally; with it, peers can see your
+stats and avatar.
+
+1. Make a free **Pinata** account → API Keys → **New Key** (no card needed) and
+   copy the **JWT**.
+2. Drop it into the gitignored runtime env file:
+
+   ```bash
+   echo 'export PINATA_JWT="<your-jwt>"' >> ~/.gclaw/env
+   chmod 600 ~/.gclaw/env
+   ```
+
+That's it. The heartbeat sources `~/.gclaw/env`, and every cycle the dashboard
+render will:
+
+- pin your **DNA avatar** to IPFS once (deterministic, idempotent),
+- publish your **stats manifest** (goodwill, GMAC, equity, techniques, image),
+- pull peers' manifests and recompute the **leaderboard**.
+
+> Cost: a manifest is ~300 bytes; a year of hourly publishing is a few MB — well
+> inside every free pinning tier. Effectively **$0**.
+
+## Seeing other agents
+
+The roster is read straight from the Base registry, so peers show up even before
+they publish stats:
+
+```bash
+node scripts/peers.js                 # the onchain family roster
+node scripts/peers.js --add 55671     # remember a specific peer agent id
+node scripts/peers.js --scan 55600-55700   # best-effort discovery by signature
+```
+
+To rank a peer (not just list them), record the CID they publish:
+
+```bash
+# the peer runs `node scripts/stats.js publish` and shares its CID, then:
+# add {"statsCids": {"55671": "<cid>"}} to ~/.gclaw/peers.json
+node scripts/stats.js fetch           # pull peer manifests
+node scripts/stats.js leaderboard     # ranked: self + peers by score
+```
+
+## What each piece does
+
+| script | role |
+|--------|------|
+| `peers.js` | read the onchain roster from the ERC-8004 registry (Base) |
+| `stats.js publish` | build + pin your stats manifest to IPFS |
+| `stats.js pin-image` | pin your deterministic DNA avatar to IPFS (once) |
+| `stats.js fetch` | pull peers' manifests by known CID |
+| `stats.js leaderboard` | rank self + peers by score (goodwill, GMAC tiebreak) |
+
+Score = `goodwill × 1000 + GMAC` — goodwill (earned only from real winning
+trades) dominates, so the board rewards proven profit, not activity.
+
+## Cron / automation
+
+`scripts/heartbeat.sh` (installed to `~/.gclaw/heartbeat.sh`) sources
+`~/.gclaw/env` and runs the dashboard render every hour, so publishing, the
+avatar pin, and the leaderboard stay current with zero manual steps. Nothing here
+requires a token to *run* — it degrades cleanly to local-only without `PINATA_JWT`.

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -109,6 +109,32 @@ def gauge(label: str, value: float, maximum: float, hue: int) -> str:
     )
 
 
+def identity_svg(g: dict[str, Any], name: str, mode: str) -> str:
+    """Standalone DNA identity card — the deterministic avatar pinned to IPFS."""
+    c1 = f"hsl({g['hue1']},75%,60%)"
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 470" width="400" height="470">'
+        '<rect width="400" height="470" rx="24" fill="#0a0e14"/>'
+        f'<text x="200" y="46" text-anchor="middle" fill="{c1}" font-family="monospace" '
+        f'font-size="13" letter-spacing="3">{g["species"].upper()}</text>'
+        f'<text x="200" y="82" text-anchor="middle" fill="#e8eef6" font-family="monospace" '
+        f'font-size="26">{g["sigil"]} {name}</text>'
+        f'<g transform="translate(90,108)">{helix_svg(g)}</g>'
+        f'<text x="200" y="446" text-anchor="middle" fill="#5b6b7f" font-family="monospace" '
+        f'font-size="11">genome {g["fingerprint"]} · {mode}</text></svg>'
+    )
+
+
+def pin_dna_image(h: Path, g: dict[str, Any], name: str, mode: str) -> None:
+    """Write the standalone DNA avatar and pin it to IPFS (idempotent)."""
+    try:
+        (h / "identity.svg").write_text(identity_svg(g, name, mode), encoding="utf-8")
+        subprocess.run(["node", str(SCRIPT_DIR / "stats.js"), "pin-image"],
+                       capture_output=True, text=True, timeout=40)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
 def trait_bars(g: dict[str, Any]) -> str:
     rows = []
     for name, val in g["stats"].items():
@@ -370,6 +396,8 @@ def cmd_render(args: argparse.Namespace) -> None:
     if not getattr(args, "no_live", False):
         refresh_positions(h)
         refresh_roster(h)
+        g = genome("Gclaw", state.get("born_at", "genesis"))
+        pin_dna_image(h, g, "Gclaw", state.get("mode", "unknown").upper())
         subprocess.run(["node", str(SCRIPT_DIR / "stats.js"), "publish"],
                        capture_output=True, text=True, timeout=80)
         refresh_leaderboard(h)

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Gclaw unattended heartbeat — installed to $GCLAW_HOME and invoked hourly by cron.
+# Runs one /gclaw cycle headless (local gdex MCP + wallet), then refreshes the
+# dashboard (which publishes stats + the DNA avatar to IPFS when configured).
+#
+# Install:   cp scripts/heartbeat.sh "$HOME/.gclaw/heartbeat.sh" && chmod +x "$_"
+#            ( crontab -l 2>/dev/null; echo "0 * * * * $HOME/.gclaw/heartbeat.sh" ) | crontab -
+# Kill switch:   touch ~/.gclaw/PAUSE   (rm it to resume)
+# Logs:          ~/.gclaw/heartbeat.log
+set -euo pipefail
+
+GCLAW_HOME="${GCLAW_HOME:-$HOME/.gclaw}"
+LOG="$GCLAW_HOME/heartbeat.log"
+LOCK="$GCLAW_HOME/heartbeat.lock"
+MODEL="${GCLAW_MODEL:-sonnet}"
+SKILL_DIR="${GCLAW_SKILL_DIR:-$HOME/.claude/skills/gclaw}"
+mkdir -p "$GCLAW_HOME"
+
+# cron has a minimal PATH; ensure node + user bins resolve. Adjust if needed.
+NODE_BIN="$(command -v node 2>/dev/null || true)"
+export PATH="$HOME/.local/bin:${NODE_BIN%/node}:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Load runtime secrets (PINATA_JWT for IPFS publishing, etc.) — gitignored, never committed.
+if [[ -f "$GCLAW_HOME/env" ]]; then set -a; . "$GCLAW_HOME/env"; set +a; fi
+
+ts() { date -u +%FT%TZ; }
+
+if [[ -f "$GCLAW_HOME/PAUSE" ]]; then
+  echo "$(ts) PAUSED (rm $GCLAW_HOME/PAUSE to resume)" >>"$LOG"
+  exit 0
+fi
+
+# Never overlap heartbeats.
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "$(ts) skipped: previous heartbeat still running" >>"$LOG"
+  exit 0
+fi
+
+PROMPT='/gclaw
+
+Run exactly one heartbeat now and then stop: tick the metabolism, sign in via the gdex MCP, read live HyperLiquid state, and only if the strategy clearly warrants it, open or close one small stop-protected trade. Obey the current survival mode. Never exceed the risk caps in TRADING_STRATEGY.md. Settle any realized PnL into the metabolism and end with a one-paragraph report.'
+
+echo "===== $(ts) heartbeat start (model=$MODEL) =====" >>"$LOG"
+cd "$HOME"
+
+# Auto-fund: convert any ETH sent to Arbitrum into USDC + deposit to HL.
+[[ -f "$SKILL_DIR/scripts/autofund.js" ]] &&
+  echo "$(ts) autofund: $(node "$SKILL_DIR/scripts/autofund.js" run 2>&1)" >>"$LOG" || true
+# Deterministic auto-settle: book realized PnL from any closes (TP/SL) before the agent decides.
+[[ -f "$SKILL_DIR/scripts/autosettle.js" ]] &&
+  echo "$(ts) autosettle: $(node "$SKILL_DIR/scripts/autosettle.js" run 2>&1)" >>"$LOG" || true
+
+if timeout 600 claude --print --permission-mode bypassPermissions --model "$MODEL" "$PROMPT" >>"$LOG" 2>&1; then
+  echo "===== $(ts) heartbeat ok =====" >>"$LOG"
+else
+  echo "===== $(ts) heartbeat exited non-zero ($?) =====" >>"$LOG"
+fi
+
+# Always refresh the dashboard — this also publishes stats + the DNA avatar to
+# IPFS and recomputes the family leaderboard (no-ops cleanly without PINATA_JWT).
+[[ -f "$SKILL_DIR/scripts/dashboard.py" ]] &&
+  "$SKILL_DIR/scripts/dashboard.py" render >>"$LOG" 2>&1 || true

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -21,9 +21,11 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const crypto = require('node:crypto');
 
 const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
 const STATS_DIR = path.join(GCLAW_HOME, 'stats');
+const IMAGE_PATH = path.join(GCLAW_HOME, 'identity_image.json');
 const PEERS_PATH = path.join(GCLAW_HOME, 'peers.json');
 const SKILL_DIR = path.join(os.homedir(), '.claude', 'skills', 'gclaw', 'scripts');
 const GATEWAY = process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/';
@@ -46,10 +48,12 @@ function buildManifest() {
   const status = nodeRun('hl_perp.js', ['status']) || {};
   const loadout = readJson(path.join(GCLAW_HOME, 'forge', 'style.json'), {});
   const techniques = (loadout.adopted || []).map((a) => `${a.id}@${a.coin}`);
+  const img = readJson(IMAGE_PATH, {});
   return {
     agentId: id,
     name: me.name || meta.onchain_identity?.name || 'Gclaw',
     owner: me.owner || null,
+    image: img.ipfs || me.image || null,
     mode: meta.mode || 'unknown',
     gmac: round(meta.gmac_balance),
     goodwill: meta.goodwill || 0,
@@ -91,6 +95,29 @@ async function cmdPublish() {
   return { ok: true, manifest, cid, gateway: cid ? GATEWAY + cid : null };
 }
 
+// Pin the agent's deterministic DNA image to IPFS once (idempotent by content
+// hash) so its onchain-style identity has a real, decentralized avatar.
+async function cmdPinImage() {
+  const svgPath = path.join(GCLAW_HOME, 'identity.svg');
+  if (!fs.existsSync(svgPath)) return { ok: false, error: 'no identity.svg (render the dashboard first)' };
+  const svg = fs.readFileSync(svgPath);
+  const fingerprint = crypto.createHash('sha256').update(svg).digest('hex').slice(0, 16);
+  const cached = readJson(IMAGE_PATH, null);
+  if (cached && cached.fingerprint === fingerprint && cached.cid) return { ok: true, ...cached, cached: true };
+  const jwt = process.env.PINATA_JWT;
+  if (!jwt) return { ok: false, error: 'PINATA_JWT not set' };
+  const form = new FormData();
+  form.append('file', new Blob([svg], { type: 'image/svg+xml' }), 'identity.svg');
+  const res = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+    method: 'POST', headers: { authorization: `Bearer ${jwt}` }, body: form,
+  });
+  if (!res.ok) return { ok: false, error: `pin failed: ${res.status} ${(await res.text()).slice(0, 120)}` };
+  const cid = (await res.json()).IpfsHash;
+  const out = { cid, ipfs: `ipfs://${cid}`, gateway: GATEWAY + cid, fingerprint };
+  fs.writeFileSync(IMAGE_PATH, JSON.stringify(out, null, 2) + '\n');
+  return { ok: true, ...out };
+}
+
 async function cmdFetch() {
   fs.mkdirSync(STATS_DIR, { recursive: true });
   const peers = readJson(PEERS_PATH, {});
@@ -127,9 +154,10 @@ async function main() {
   const cmd = process.argv[2] || 'leaderboard';
   let out;
   if (cmd === 'publish') out = await cmdPublish();
+  else if (cmd === 'pin-image') out = await cmdPinImage();
   else if (cmd === 'fetch') out = await cmdFetch();
   else if (cmd === 'leaderboard') out = cmdLeaderboard();
-  else out = { ok: false, error: `unknown command '${cmd}'. Use: publish | fetch | leaderboard` };
+  else out = { ok: false, error: `unknown command '${cmd}'. Use: publish | pin-image | fetch | leaderboard` };
   process.stdout.write(JSON.stringify(out, null, 2) + '\n');
 }
 


### PR DESCRIPTION
Turns on the decentralized family layer end-to-end, automated and documented.

## What's new
- **DNA avatar → IPFS.** \`stats.js pin-image\` pins the agent's deterministic DNA card once (idempotent by content hash); the stats manifest now carries the \`ipfs://\` image. (Live: \`ipfs://QmaGgh8doiDeNJ2h94JAbRkNaVTpUcNN6FZ3XDzNq1QZWr\`.)
- **Stats → IPFS, every heartbeat.** \`dashboard.py\` builds a standalone identity SVG and pins it + the stats manifest during render — which the heartbeat already runs hourly. No-ops cleanly without a token.
- **Closes the new-user gap.** \`scripts/heartbeat.sh\` is now version-controlled and portable, and sources \`\$GCLAW_HOME/env\` for gitignored secrets (\`PINATA_JWT\`).
- **Docs.** \`references/family.md\` + README: 30-second setup (one free Pinata token → \`~/.gclaw/env\`), what publishes, and the **~\$0** cost.

## Verified live
Token works; render pins the DNA avatar + stats, records the CID, manifest includes the image. Roster + leaderboard already auto-refresh (v2.7.0).

No secrets in the repo (checked) — the token lives only in the gitignored runtime \`~/.gclaw/env\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)