### PR TITLE
Auto-exchange peer stats via an onchain beacon

### DIFF
--- a/references/family.md
+++ b/references/family.md
@@ -41,14 +41,24 @@ node scripts/peers.js --add 55671     # remember a specific peer agent id
 node scripts/peers.js --scan 55600-55700   # best-effort discovery by signature
 ```
 
-To rank a peer (not just list them), record the CID they publish:
+Peers rank **automatically** — no CID exchange. Each agent writes a tiny stats
+beacon (goodwill, GMAC, score, manifest CID) into its **onchain card** via
+`setAgentURI`, and `peers.js` reads it straight back from the registry. So once a
+peer's heartbeat runs, it appears on everyone's leaderboard with no coordination:
 
 ```bash
-# the peer runs `node scripts/stats.js publish` and shares its CID, then:
-# add {"statsCids": {"55671": "<cid>"}} to ~/.gclaw/peers.json
-node scripts/stats.js fetch           # pull peer manifests
-node scripts/stats.js leaderboard     # ranked: self + peers by score
+node scripts/erc8004_register.js beacon   # push our card onchain (throttled)
+node scripts/stats.js leaderboard         # ranked: self + peers, read from chain
 ```
+
+The beacon is **throttled** — it only writes onchain when goodwill (the ranking
+metric) changes or the card is >12h stale, so gas stays minimal (~$0.001/tx on
+Base, only on real change). It needs a little Base ETH in the control wallet for
+gas; without it, the beacon no-ops and the agent still ranks locally.
+
+> Full IPFS manifests (`stats.js fetch` by CID) remain available for richer
+> peer detail, but are not required for the leaderboard — the onchain beacon
+> carries the headline standings.
 
 ## What each piece does
 

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -395,11 +395,14 @@ def cmd_render(args: argparse.Namespace) -> None:
         raise SystemExit(f"No metabolism state at {h}. Run metabolism.py init first.")
     if not getattr(args, "no_live", False):
         refresh_positions(h)
-        refresh_roster(h)
         g = genome("Gclaw", state.get("born_at", "genesis"))
         pin_dna_image(h, g, "Gclaw", state.get("mode", "unknown").upper())
-        subprocess.run(["node", str(SCRIPT_DIR / "stats.js"), "publish"],
-                       capture_output=True, text=True, timeout=80)
+        # Publish to IPFS, then beacon the card onchain (throttled) so peers read
+        # our standings, then read the roster (incl. peer beacons) and rank.
+        for step in (["stats.js", "publish"], ["erc8004_register.js", "beacon"]):
+            subprocess.run(["node", str(SCRIPT_DIR / step[0]), *step[1:]],
+                           capture_output=True, text=True, timeout=80)
+        refresh_roster(h)
         refresh_leaderboard(h)
     journal = read_jsonl(h / "journal.jsonl")
     messages = read_jsonl(h / "telepathy" / "bus.jsonl")

--- a/scripts/erc8004_register.js
+++ b/scripts/erc8004_register.js
@@ -83,6 +83,24 @@ function genome(name, bornAt) {
   };
 }
 
+function statsForCard(state) {
+  const id = state.onchain_identity?.agentId;
+  if (!id) return null;
+  let manifest = {};
+  try { manifest = JSON.parse(fs.readFileSync(path.join(GCLAW_HOME, 'stats', `${id}.json`), 'utf8')); } catch { /* no manifest yet */ }
+  let cids = {};
+  try { cids = JSON.parse(fs.readFileSync(path.join(GCLAW_HOME, 'peers.json'), 'utf8')).statsCids || {}; } catch { /* none */ }
+  return {
+    cid: cids[id] || null,
+    goodwill: manifest.goodwill ?? state.goodwill ?? 0,
+    gmac: manifest.gmac ?? state.gmac_balance ?? null,
+    equityUsd: manifest.equityUsd ?? null,
+    score: manifest.score ?? null,
+    techniques: manifest.techniques || [],
+    updatedAt: manifest.updatedAt || new Date().toISOString(),
+  };
+}
+
 function agentCard(state, managed, child) {
   const name = child ? child.name : 'Gclaw';
   const bornAt = child ? child.born_at : state.born_at || 'genesis';
@@ -106,6 +124,7 @@ function agentCard(state, managed, child) {
       goodwill: child ? 0 : state.goodwill ?? 0,
       controlWallet: JSON.parse(fs.readFileSync(WALLET_PATH, 'utf8')).control.address,
       managedHlWallet: managed,
+      ...(child ? {} : { stats: statsForCard(state) }),
       ...lineage,
     },
   };
@@ -134,8 +153,8 @@ function registerInLeaderboard(agentId) {
 
 async function main() {
   const mode = process.argv[2];
-  if (!['dry-run', 'broadcast', 'update'].includes(mode)) {
-    throw new Error('usage: erc8004_register.js <dry-run|broadcast|update> [--child <name>]');
+  if (!['dry-run', 'broadcast', 'update', 'beacon'].includes(mode)) {
+    throw new Error('usage: erc8004_register.js <dry-run|broadcast|update|beacon> [--child <name>]');
   }
   const childName = process.argv.includes('--child') ? process.argv[process.argv.indexOf('--child') + 1] : null;
   const state = JSON.parse(fs.readFileSync(path.join(GCLAW_HOME, 'metabolism.json'), 'utf8'));
@@ -165,6 +184,33 @@ async function main() {
     }
     console.log(`DRY-RUN OK — would mint agentId=${agentId.toString()} | gas≈${gas}`);
     console.log(`card: ${JSON.stringify(card)}`);
+    return;
+  }
+
+  if (mode === 'beacon') {
+    // Push the live stats card onchain so peers read our standings directly — but
+    // only when it matters: goodwill changed (the ranking metric) or it's stale,
+    // so gas stays minimal. No-ops cleanly when not registered or gas is too low.
+    const idRecord = state.onchain_identity;
+    if (!idRecord?.agentId) { console.log(JSON.stringify({ ok: false, skip: 'not registered' })); return; }
+    const beaconPath = path.join(GCLAW_HOME, 'beacon.json');
+    let last = {};
+    try { last = JSON.parse(fs.readFileSync(beaconPath, 'utf8')); } catch { /* first push */ }
+    const goodwill = card['x-gclaw'].stats?.goodwill ?? 0;
+    const hours = last.ts ? (Date.now() - new Date(last.ts).getTime()) / 3.6e6 : Infinity;
+    if (goodwill === last.goodwill && hours < 12) {
+      console.log(JSON.stringify({ ok: true, skipped: 'no goodwill change, fresh', goodwill }));
+      return;
+    }
+    if (bal < ethers.parseEther('0.00002')) {
+      console.log(JSON.stringify({ ok: false, skip: 'low Base ETH for gas', bal: ethers.formatEther(bal) }));
+      return;
+    }
+    const tx = await registry.setAgentURI(BigInt(idRecord.agentId), uri);
+    const receipt = await tx.wait();
+    const rec = { goodwill, score: card['x-gclaw'].stats?.score ?? null, ts: new Date().toISOString(), tx: tx.hash, block: receipt.blockNumber };
+    fs.writeFileSync(beaconPath, JSON.stringify(rec, null, 2) + '\n');
+    console.log(JSON.stringify({ ok: true, pushed: true, ...rec }));
     return;
   }
 

--- a/scripts/peers.js
+++ b/scripts/peers.js
@@ -57,6 +57,7 @@ async function readAgent(id) {
   }
   const owner = ownerRaw && ownerRaw !== '0x' ? '0x' + ownerRaw.slice(-40) : null;
   return { id: Number(id), name: meta.name || null, owner, image: meta.image || null,
+    stats: meta['x-gclaw']?.stats || null,  // live standings beacon, read straight from chain
     isGclaw: typeof meta.description === 'string' && meta.description.includes(SIGNATURE) };
 }
 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -141,9 +141,19 @@ function cmdLeaderboard() {
   const ranked = [];
   const pending = [];
   for (const a of roster) {
-    const m = readJson(path.join(STATS_DIR, `${a.id}.json`), null);
-    if (m) ranked.push({ ...m, self: a.id === selfId });
-    else pending.push({ agentId: a.id, name: a.name, self: a.id === selfId });
+    // Prefer a fully-fetched IPFS manifest; otherwise use the onchain beacon the
+    // peer wrote into its card (read by peers.js) — no manual CID exchange needed.
+    const local = readJson(path.join(STATS_DIR, `${a.id}.json`), null);
+    const src = local || (a.stats && a.stats.score != null ? { agentId: a.id, name: a.name, ...a.stats } : null);
+    if (src && src.score != null) {
+      ranked.push({
+        agentId: a.id, name: a.name || src.name, goodwill: src.goodwill, gmac: src.gmac,
+        equityUsd: src.equityUsd, score: src.score, image: a.image || src.image,
+        source: local ? 'ipfs' : 'onchain', self: a.id === selfId,
+      });
+    } else {
+      pending.push({ agentId: a.id, name: a.name, self: a.id === selfId });
+    }
   }
   ranked.sort((x, y) => y.score - x.score);
   ranked.forEach((e, i) => { e.rank = i + 1; });


### PR DESCRIPTION
Closes the last manual step: cross-machine leaderboard ranking with **zero coordination**.

## How
Each agent writes a tiny stats beacon — `{goodwill, gmac, score, manifest CID}` — into its **ERC-8004 onchain card** via `setAgentURI`, and `peers.js` reads it straight back from the registry. Any peer appears on everyone's leaderboard the moment its own heartbeat runs. No CID exchange, no shared secrets.

- `erc8004_register.js beacon` — embeds `x-gclaw.stats` in the card, pushes onchain **throttled** (only on goodwill change or >12h staleness), no-ops without gas/registration.
- `peers.js` — parses `x-gclaw.stats` from each card.
- `stats.js leaderboard` — ranks from the onchain beacon (`source: onchain`) or a fetched IPFS manifest (`source: ipfs`).
- `dashboard.py` — publish → beacon → read roster → rank, every heartbeat.

## Verified live
Beacon pushed Zephlith's card onchain (tx `0x7acd8ca2…`, block 47508718); `peers.js` read `goodwill=0 score=933.6 cid=Qm…` back from chain; leaderboard ranked it #1. Blaq Ceaser G ranks automatically once on this version + a heartbeat.

Gas: ~\$0.001/tx on Base, only on real change. Control wallet funds it; degrades to local-only without gas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)