### PR TITLE
SECURITY: close fund-drain vectors (sandbox RCE + fund-exit tools)

### DIFF
--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -68,8 +68,38 @@ ALLOWED_IMPORTS = {"math", "statistics"}
 BANNED_NAMES = {
     "eval", "exec", "open", "__import__", "compile", "input", "globals",
     "locals", "getattr", "setattr", "vars", "delattr", "memoryview",
+    "__builtins__", "breakpoint", "help", "object", "type", "super",
+    "classmethod", "staticmethod", "property",
 }
+# Attribute access that can pivot to builtins/globals even without a dunder name.
+BANNED_ATTRS = {"format", "format_map", "mro", "__class__", "__globals__", "__subclasses__"}
 SIGNAL_TIMEOUT_S = 2
+
+
+def _safe_import(name: str, *_a: Any, **_k: Any) -> Any:
+    """The only import a signal may perform — the allow-listed math libs."""
+    import math
+    import statistics
+    allowed = {"math": math, "statistics": statistics}
+    if name in allowed:
+        return allowed[name]
+    raise ImportError(f"import '{name}' is not allowed in a technique signal")
+
+
+def _safe_builtins() -> dict[str, Any]:
+    """A minimal builtins set with NO code-exec / introspection / io escape hatches.
+
+    Restricting `__builtins__` in the exec namespace is the load-bearing control:
+    it removes the `__builtins__['__import__']('os')` subscript escape that the AST
+    validator alone cannot see. The validator is defense-in-depth on top.
+    """
+    safe = ("abs", "min", "max", "round", "sum", "len", "range", "sorted", "enumerate",
+            "zip", "map", "filter", "any", "all", "pow", "divmod", "float", "int",
+            "bool", "str", "list", "dict", "tuple", "set", "abs", "isinstance")
+    import builtins
+    out: dict[str, Any] = {k: getattr(builtins, k) for k in safe}
+    out["__import__"] = _safe_import
+    return out
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 
@@ -289,10 +319,10 @@ def validate_signal_src(src: str) -> list[str]:
         elif isinstance(node, ast.ImportFrom):
             if (node.module or "").split(".")[0] not in ALLOWED_IMPORTS:
                 violations.append(f"import not allowed: from {node.module}")
-        elif isinstance(node, ast.Name) and node.id in BANNED_NAMES:
+        elif isinstance(node, ast.Name) and (node.id in BANNED_NAMES or node.id.startswith("__")):
             violations.append(f"banned name: {node.id}")
-        elif isinstance(node, ast.Attribute) and node.attr.startswith("__"):
-            violations.append(f"dunder access not allowed: {node.attr}")
+        elif isinstance(node, ast.Attribute) and (node.attr.startswith("__") or node.attr in BANNED_ATTRS):
+            violations.append(f"banned attribute access: {node.attr}")
     if not any(isinstance(n, ast.FunctionDef) and n.name == "signal"
                for n in ast.walk(tree)):
         violations.append("missing required function: signal(features)")
@@ -304,8 +334,10 @@ def _compile_signal(src: str, where: str) -> Callable[[dict[str, Any]], Any]:
     violations = validate_signal_src(src)
     if violations:
         raise ValueError("; ".join(violations))
-    namespace: dict[str, Any] = {}
-    exec(compile(src, where, "exec"), namespace)  # noqa: S102 — AST-validated above
+    # Restricted builtins are the real boundary; the AST validation is defence in
+    # depth. Together they close the __builtins__/__import__ subscript escape.
+    namespace: dict[str, Any] = {"__builtins__": _safe_builtins()}
+    exec(compile(src, where, "exec"), namespace)  # noqa: S102 — sandboxed builtins + AST-validated
     return namespace["signal"]
 
 

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -51,7 +51,14 @@ cd "$HOME"
 [[ -f "$SKILL_DIR/scripts/autosettle.js" ]] &&
   echo "$(ts) autosettle: $(node "$SKILL_DIR/scripts/autosettle.js" run 2>&1)" >>"$LOG" || true
 
-if timeout 600 claude --print --permission-mode bypassPermissions --model "$MODEL" "$PROMPT" >>"$LOG" 2>&1; then
+# Anti-drain: the heartbeat runs unattended with bypassPermissions, and reads
+# untrusted text (peer cards, family bus, market data, gene-pool metadata) that
+# could carry a prompt-injection payload. Deny every tool that can move funds to
+# an arbitrary destination — legit funding is done by deterministic scripts
+# (autofund/gmac_buy) with HARD-CODED destinations, never by the model.
+DENY="mcp__gdex__transfer_native,mcp__gdex__transfer_token,mcp__gdex__execute_bridge,mcp__gdex__perp_withdraw,mcp__gdex__hl_swap_collateral,mcp__gdex__managed_sell,mcp__gdex__sell_token"
+if timeout 600 claude --print --permission-mode bypassPermissions --model "$MODEL" \
+    --disallowedTools "$DENY" "$PROMPT" >>"$LOG" 2>&1; then
   echo "===== $(ts) heartbeat ok =====" >>"$LOG"
 else
   echo "===== $(ts) heartbeat exited non-zero ($?) =====" >>"$LOG"


### PR DESCRIPTION
P0 — real-money bot holding wallet keys. Two confirmed drain vectors closed.

### 1. Technique sandbox RCE (confirmed exploit)
A signal passing the AST validator could escape: `__builtins__['__import__']('os')` — proven to set `os.environ` in a probe. `exec` was injecting full builtins and the validator didn't see the subscript. Fix: exec now runs with a **minimal restricted `__builtins__`** (no eval/exec/open; imports go through a math-only `_safe_import`), and the validator additionally bans `__builtins__`, all dunder names, and `format`/`mro`/`__class__` attribute pivots. Verified: every known escape blocked, legit signals still compile + run. This is the prerequisite for ever sharing techniques across machines.

### 2. Prompt-injection → fund exit
The heartbeat runs `bypassPermissions` and reads untrusted text (peer cards, bus, market data). It now passes `--disallowedTools` for every fund-exit tool (`transfer_native`, `transfer_token`, `execute_bridge`, `perp_withdraw`, `hl_swap_collateral`, sells). Legit funding stays in deterministic scripts with hard-coded destinations, so nothing breaks.

Key handling audited: the control private key is only used for local signing, never logged or sent; wallet file is gitignored.

Refs assune-kc8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)