### PR TITLE
Circuit breaker + health alerting

### DIFF
--- a/references/safety.md
+++ b/references/safety.md
@@ -1,0 +1,35 @@
+# Safety & security model
+
+This is a real-money agent that holds wallet keys, so the design assumes the
+network is adversarial. The controls below exist so a creature can't be drained.
+
+## Anti-drain controls
+
+| Vector | Control |
+|---|---|
+| **Untrusted technique code (RCE)** | The forge executes `signal.py` only inside a sandbox: an AST allow-list (imports limited to `math`/`statistics`, dunder/`__builtins__`/`format`/`getattr`/`eval`/`exec`/`open` banned) **and** a restricted `exec` `__builtins__` with a math-only `_safe_import`. The `__builtins__['__import__']('os')` escape is closed at both layers. **Do not auto-execute peer-supplied code** — cross-machine sharing must share data/specs, not code, or run pulled code isolated + draft-only. |
+| **Prompt injection → fund exit** | The heartbeat runs unattended (`bypassPermissions`) and reads untrusted text (peer cards, family bus, market data, gene-pool metadata). It denies every tool that can move funds to an arbitrary destination: `transfer_native`, `transfer_token`, `execute_bridge`, `perp_withdraw`, `hl_swap_collateral`, sells. Legit funding is done by deterministic scripts (`autofund`, `gmac_buy`) with **hard-coded destinations** — never by the model. |
+| **Key exposure** | The control private key is used only for local `ethers.Wallet` signing; it is never logged or sent. Wallet files (`*-wallet.json`) and secrets (`~/.gclaw/env`) are gitignored. |
+| **Runaway losses** | A portfolio **circuit breaker** halts new entries (never blocks closing) when equity falls ≥25% from its high-water mark or there are ≥3 open positions. Per-trade risk is also capped (5% / 2% in survive) with a mandatory stop. |
+
+## Health alerting
+
+Set `GCLAW_ALERT_WEBHOOK` (Slack/Discord/generic JSON) and/or `GCLAW_TELEGRAM_TOKEN`
++ `GCLAW_TELEGRAM_CHAT` in `~/.gclaw/env`. Each heartbeat runs `notify.js check`
+and pings on the *transition* into a red state:
+
+- **hibernate** (out of GMAC) — fund it to revive
+- **low beacon gas** — top up Base ETH
+- **circuit breaker tripped** — drawdown / too many positions
+- **trading funds low** while flat
+
+No webhook → it no-ops. Errors (heartbeat exit non-zero) alert immediately.
+
+## What still needs your trust
+
+- The wallet's **managed custody** is operated by GDEX; this design can't move
+  funds out via the model, but custody itself is a trust assumption.
+- **Live deployed config** (registry owner, attester) is onchain — verify it.
+- The sandbox raises the bar a lot but in-process Python isolation is not a
+  hard boundary; treat any *peer-pulled* code as untrusted and keep it
+  data-only / draft-only until a process-isolated runner exists.

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -883,9 +883,41 @@ def _account() -> dict[str, float]:
                               capture_output=True, text=True, timeout=90)
         st = json.loads(proc.stdout.strip().splitlines()[-1])
         equity = float(st.get("equity") or st.get("spotUsdc") or st.get("accountValue") or 0)
-        return {"equity": equity, "buying_power": float(st.get("buyingPower") or equity)}
+        return {"equity": equity, "buying_power": float(st.get("buyingPower") or equity),
+                "positions": len(st.get("positions") or [])}
     except Exception:
-        return {"equity": 0.0, "buying_power": 0.0}
+        return {"equity": 0.0, "buying_power": 0.0, "positions": 0}
+
+
+# Portfolio circuit breaker — halts NEW entries (never closes/blocks risk-reduction)
+# when the account is in trouble, independent of the GMAC life-energy mode.
+MAX_DRAWDOWN_PCT = 25  # halt new entries if equity falls this far below its high-water mark
+MAX_OPEN_POSITIONS = 3  # cap concurrent positions to bound concentration
+
+
+def circuit_breaker(equity: float, n_positions: int) -> dict[str, Any]:
+    """Update the equity high-water mark and decide whether new entries are allowed."""
+    path = gclaw_home() / "breaker.json"
+    state = {}
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        pass
+    hwm = max(float(state.get("hwm", 0) or 0), equity)
+    drawdown_pct = round((1 - equity / hwm) * 100, 2) if hwm > 0 else 0.0
+    reason = None
+    if drawdown_pct >= MAX_DRAWDOWN_PCT:
+        reason = f"drawdown {drawdown_pct}% ≥ {MAX_DRAWDOWN_PCT}% from high-water ${hwm:.2f}"
+    elif n_positions >= MAX_OPEN_POSITIONS:
+        reason = f"{n_positions} open positions ≥ {MAX_OPEN_POSITIONS} cap"
+    state.update({"hwm": round(hwm, 2), "equity": round(equity, 2),
+                  "drawdown_pct": drawdown_pct, "positions": n_positions,
+                  "tripped": bool(reason), "reason": reason, "at": now_iso()})
+    try:
+        path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+    return {"allow_entry": not reason, "reason": reason, "drawdown_pct": drawdown_pct, "hwm": round(hwm, 2)}
 
 
 def _intent(tid: str, coin: str, decision: dict[str, Any], mode: str, equity: float,
@@ -956,12 +988,14 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
             intent["proven"] = coin == proven_coin.get(tid)
             intents.append(intent)
     intents.sort(key=lambda x: x["confidence"], reverse=True)
+    breaker = circuit_breaker(equity, acct.get("positions", 0))
     result = {"ok": True, "mode": mode, "leverage_cap": cap, "equity": equity,
-              "buying_power": round(buying_power, 2), "intents": intents}
+              "buying_power": round(buying_power, 2), "breaker": breaker, "intents": intents}
     # Auto-execute only a signal on its proven market; cross-market signals are
-    # surfaced as exploration for the heartbeat to act on (or prove next).
+    # surfaced as exploration for the heartbeat to act on (or prove next). The
+    # circuit breaker can halt new entries (it never blocks closing risk).
     proven = [i for i in intents if i["proven"] and i["notional"] >= MIN_NOTIONAL]
-    if args.execute and proven and mode != "hibernate":
+    if args.execute and proven and mode != "hibernate" and breaker["allow_entry"]:
         top = proven[0]
         result["executed"] = _execute(top)
         if result["executed"].get("ok"):
@@ -970,6 +1004,8 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
             pending[top["coin"]] = {"ref": ref, "technique": top["technique"], "opened_at": now_iso()}
             save_pending(pending)
             result["attribution"] = {"coin": top["coin"], "credit_to": ref}
+    elif args.execute and not breaker["allow_entry"]:
+        result["executed"] = {"skipped": f"circuit breaker: {breaker['reason']}"}
     elif args.execute:
         result["executed"] = {"skipped": "no proven-market signal (exploration intents not auto-traded)"}
     return result

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -62,9 +62,16 @@ if timeout 600 claude --print --permission-mode bypassPermissions --model "$MODE
   echo "===== $(ts) heartbeat ok =====" >>"$LOG"
 else
   echo "===== $(ts) heartbeat exited non-zero ($?) =====" >>"$LOG"
+  [[ -f "$SKILL_DIR/scripts/notify.js" ]] &&
+    node "$SKILL_DIR/scripts/notify.js" send critical "heartbeat exited non-zero" >>"$LOG" 2>&1 || true
 fi
 
 # Always refresh the dashboard — this also publishes stats + the DNA avatar to
 # IPFS and recomputes the family leaderboard (no-ops cleanly without PINATA_JWT).
 [[ -f "$SKILL_DIR/scripts/dashboard.py" ]] &&
   "$SKILL_DIR/scripts/dashboard.py" render >>"$LOG" 2>&1 || true
+
+# Health alerts (best-effort): notify on red conditions (hibernate, low gas,
+# tripped breaker, low funds) when GCLAW_ALERT_WEBHOOK is set. No-ops otherwise.
+[[ -f "$SKILL_DIR/scripts/notify.js" ]] &&
+  echo "$(ts) alerts: $(node "$SKILL_DIR/scripts/notify.js" check 2>&1)" >>"$LOG" || true

--- a/scripts/notify.js
+++ b/scripts/notify.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Health alerting for the unattended bot — so a silent failure never goes unseen.
+ *
+ *   node notify.js send <level> <message...>   # push one alert
+ *   node notify.js check                        # evaluate red conditions, alert on new ones
+ *
+ * Posts to GCLAW_ALERT_WEBHOOK (Slack/Discord/generic JSON — sends both `text`
+ * and `content`) and optionally Telegram (GCLAW_TELEGRAM_TOKEN + _CHAT). No-ops
+ * cleanly without a webhook. `check` dedupes by condition so it alerts on the
+ * transition (entered hibernate / went low) — not every hour.
+ * Env: GCLAW_HOME, GCLAW_ALERT_WEBHOOK, GCLAW_TELEGRAM_TOKEN, GCLAW_TELEGRAM_CHAT.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
+const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+const agentId = () => readJson(path.join(GCLAW_HOME, 'metabolism.json'), {}).onchain_identity?.agentId || '?';
+
+async function post(url, body, headers) {
+  return new Promise((resolve) => {
+    try {
+      const u = new URL(url);
+      const data = JSON.stringify(body);
+      const req = require(u.protocol === 'http:' ? 'node:http' : 'node:https').request(
+        u, { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(data), ...headers } },
+        (res) => { res.on('data', () => {}); res.on('end', () => resolve(res.statusCode)); });
+      req.on('error', () => resolve(null));
+      req.write(data); req.end();
+    } catch { resolve(null); }
+  });
+}
+
+async function send(level, message) {
+  const text = `🜃 Gclaw #${agentId()} [${level.toUpperCase()}] ${message}`;
+  const out = { ok: true, sent: [] };
+  const webhook = process.env.GCLAW_ALERT_WEBHOOK;
+  if (webhook) { await post(webhook, { text, content: text, level, message }); out.sent.push('webhook'); }
+  const tg = process.env.GCLAW_TELEGRAM_TOKEN, chat = process.env.GCLAW_TELEGRAM_CHAT;
+  if (tg && chat) { await post(`https://api.telegram.org/bot${tg}/sendMessage`, { chat_id: chat, text }); out.sent.push('telegram'); }
+  if (!out.sent.length) out.skip = 'no GCLAW_ALERT_WEBHOOK / telegram configured';
+  return out;
+}
+
+function conditions() {
+  const meta = readJson(path.join(GCLAW_HOME, 'metabolism.json'), {});
+  const gas = readJson(path.join(GCLAW_HOME, 'gas.json'), {});
+  const breaker = readJson(path.join(GCLAW_HOME, 'breaker.json'), {});
+  const pos = readJson(path.join(GCLAW_HOME, 'positions.json'), {});
+  const out = {};
+  if (meta.mode === 'hibernate') out.hibernate = `HIBERNATING (GMAC ${Math.round(meta.gmac_balance || 0)}) — fund it to revive`;
+  if (gas.status && gas.status !== 'healthy') out.gas = `beacon gas ${gas.status} (~${gas.beaconRunway} left) — top up Base ETH`;
+  if (breaker.tripped) out.breaker = `circuit breaker TRIPPED: ${breaker.reason}`;
+  if (pos.ok && Number(pos.spotUsdc) < 12 && !(pos.positions || []).length) out.funds = `trading funds low ($${Number(pos.spotUsdc).toFixed(2)}) and flat`;
+  return out;
+}
+
+async function check() {
+  const cur = conditions();
+  const seenPath = path.join(GCLAW_HOME, 'alerts.json');
+  const seen = readJson(seenPath, {});
+  const fired = [];
+  for (const [k, msg] of Object.entries(cur)) {
+    if (!seen[k]) { await send(k === 'hibernate' || k === 'breaker' ? 'critical' : 'warning', msg); fired.push(k); }
+  }
+  fs.writeFileSync(seenPath, JSON.stringify(cur) + '\n');  // current = new baseline (clears resolved)
+  return { ok: true, fired, active: Object.keys(cur) };
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  let out;
+  if (cmd === 'send') out = await send(process.argv[3] || 'info', process.argv.slice(4).join(' '));
+  else if (cmd === 'check') out = await check();
+  else out = { ok: false, error: 'usage: notify.js <send <level> <msg> | check>' };
+  process.stdout.write(JSON.stringify(out) + '\n');
+}
+
+main();


### PR DESCRIPTION
Safety controls for unattended real-money operation (companion to the security PR #61).

- **Circuit breaker** (`forge.py`): equity high-water mark; halts *new* entries (never blocks closing risk) at ≥25% drawdown or ≥3 open positions. Wired into the forge execute gate. Tested: trips at 30% DD and at 4 positions, allows in normal state.
- **Health alerting** (`notify.js`): pings `GCLAW_ALERT_WEBHOOK` (Slack/Discord/JSON) + optional Telegram on the transition into hibernate / low-gas / tripped-breaker / low-funds, and immediately on heartbeat error. No-ops without a webhook.
- `references/safety.md` — the anti-drain model in one page.

Closes assune-iuu, assune-6nv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)