### PR TITLE
Book funding PnL + verified leaderboard + preserve custom names

### DIFF
--- a/leaderboard/leaderboard.html
+++ b/leaderboard/leaderboard.html
@@ -28,8 +28,9 @@ h1{margin:0;font-size:26px;letter-spacing:.5px}
 .trait b{text-align:right}
 .tbar{height:7px;background:#0c1322;border-radius:5px;overflow:hidden}.tfill{height:100%;border-radius:5px}
 .pill{display:inline-block;background:#1d2a47;color:#9db4ff;padding:1px 8px;border-radius:999px;font-size:11px;margin-top:6px}
-.stats{display:flex;gap:12px;margin:4px 0 8px;font-family:ui-monospace,monospace;font-size:13px;color:#cdd8f0}
+.stats{display:flex;gap:12px;margin:4px 0 8px;font-family:ui-monospace,monospace;font-size:13px;color:#cdd8f0;flex-wrap:wrap}
 .stats span{white-space:nowrap}
+.ver{color:#7CFFB2;border:1px solid #1f6b46;border-radius:6px;padding:0 6px}
 .muted{color:var(--muted);font-size:12px}
 .foot{max-width:1080px;margin:22px auto 0;color:var(--muted);font-size:12px;text-align:center}
 input{background:#0c1322;border:1px solid var(--line);color:var(--ink);border-radius:8px;padding:6px 10px;font:inherit;width:240px}
@@ -113,19 +114,22 @@ function traitBars(traits, fp){
 }
 
 function score(g){
-  // Rank by the live onchain trading beacon when present; fall back to genome.
+  // Rank by VERIFIED HyperLiquid equity first (independently checkable, not
+  // spoofable). Fall back to the onchain beacon, then the genome.
+  if(g.verifiedEquity!=null) return 1e9 + g.verifiedEquity;   // verified outranks unverified
   if(g.stats && g.stats.score!=null) return Number(g.stats.score);
   return (g.goodwill||0)*1000 + (g.traits?Object.values(g.traits).reduce((a,b)=>a+b,0):0);
 }
 
 function statsRow(g){
-  const s = g.stats; if(!s) return '<div class="muted">no trading beacon yet</div>';
   const money = v => (v==null?"—":(typeof v==="number"?v:Number(v)).toLocaleString());
-  return `<div class="stats">
-    <span title="goodwill — earned only from winning trades">⭐ ${s.goodwill??0}</span>
-    <span title="GMAC life energy">🜂 ${money(s.gmac)}</span>
-    <span title="HyperLiquid equity">💵 $${money(s.equityUsd)}</span>
-  </div>`;
+  const verified = g.verifiedEquity!=null
+    ? `<span class="ver" title="read live from HyperLiquid — independently verifiable">✓ $${g.verifiedEquity.toLocaleString()} verified</span>` : "";
+  const s = g.stats;
+  if(!s && !verified) return '<div class="muted">no trading beacon yet</div>';
+  const self = s ? `<span title="self-reported goodwill (winning trades)">⭐ ${s.goodwill??0}</span>
+    <span title="GMAC life energy">🜂 ${money(s.gmac)}</span>` : "";
+  return `<div class="stats">${verified}${self}</div>`;
 }
 
 function render(creatures){
@@ -148,12 +152,29 @@ function render(creatures){
   }).join("");
 }
 
+// Independently verify a creature's standings: read its managed wallet's REAL
+// equity straight from HyperLiquid's public API. Self-reported beacon stats are
+// gameable; this is the trust-minimized number anyone can check.
+async function verifyHlEquity(wallet){
+  if(!wallet) return null;
+  try{
+    const r = await fetch("https://api.hyperliquid.xyz/info", {method:"POST",
+      headers:{"content-type":"application/json"},
+      body:JSON.stringify({type:"spotClearinghouseState", user:wallet})});
+    const j = await r.json();
+    const usdc = (j.balances||[]).find(b=>b.coin==="USDC");
+    return usdc ? Number(usdc.total) : null;
+  }catch(e){ return null; }
+}
+
 async function loadAgent(id){
   const hex = await ethCall(REGISTRY, TOKEN_URI_SELECTOR + pad32(id));
   const uri = decodeString(hex);
   const card = cardFromUri(uri);
   if(!card || !card["x-gclaw"]) return null;       // not a Gclaw creature
-  return { id, name: card.name, g: card["x-gclaw"] };
+  const g = card["x-gclaw"];
+  g.verifiedEquity = await verifyHlEquity(g.managedHlWallet);
+  return { id, name: card.name, g };
 }
 
 async function main(){

--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -52,6 +52,18 @@ async function fetchFills(address) {
   return Array.isArray(h) ? h : h.data || h.fills || h.history || [];
 }
 
+// Perp funding (longs pay shorts hourly) is realized PnL too, but never appears
+// as a fill — pull it from HL's public ledger so the books don't drift.
+async function fetchFunding(address, startTime) {
+  const res = await fetch('https://api.hyperliquid.xyz/info', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ type: 'userFunding', user: address, startTime: Math.max(0, startTime || 0) }),
+  });
+  if (!res.ok) return [];
+  const rows = await res.json();
+  return (Array.isArray(rows) ? rows : []).map((x) => ({ time: x.time, usdc: Number(x.delta?.usdc || 0) }));
+}
+
 function selectNew(fills, cursor) {
   const seen = new Set(cursor.lastTids);
   return fills.filter((f) => f.time > cursor.lastTime || (f.time === cursor.lastTime && !seen.has(f.tid)));
@@ -73,23 +85,29 @@ async function main() {
   if (!['run', 'peek'].includes(mode)) throw new Error('usage: autosettle.js <run|peek>');
   const firstRun = !fs.existsSync(CURSOR_PATH);
   const cursor = loadCursor();
-  const fills = await fetchFills(managedAddress());
+  const address = managedAddress();
+  const fills = await fetchFills(address);
+  const funding = await fetchFunding(address, firstRun ? 0 : cursor.lastFundingTime || 0);
 
-  // First ever run: baseline the cursor to the latest existing fill and settle
-  // nothing — pre-baseline history (other sessions, old test trades) must not count.
+  // First ever run: baseline the cursors to the latest existing fill/funding and
+  // settle nothing — pre-baseline history must not count.
   if (firstRun && mode === 'run' && fills.length) {
     const maxTime = Math.max(...fills.map((f) => f.time));
-    saveCursor({ lastTime: maxTime, lastTids: fills.filter((f) => f.time === maxTime).map((f) => f.tid), residual: 0 });
+    const maxFunding = funding.length ? Math.max(...funding.map((x) => x.time)) : 0;
+    saveCursor({ lastTime: maxTime, lastTids: fills.filter((f) => f.time === maxTime).map((f) => f.tid), residual: 0, lastFundingTime: maxFunding });
     process.stdout.write(JSON.stringify({ ok: true, initialized: true, baselineFills: fills.length, settled: false }) + '\n');
     return;
   }
 
   const fresh = selectNew(fills, cursor);
+  const freshFunding = funding.filter((x) => x.time > (cursor.lastFundingTime || 0));
 
   const closedPnl = fresh.reduce((s, f) => s + Number(f.closedPnl || 0), 0);
   const fees = fresh.reduce((s, f) => s + Number(f.fee || 0), 0);
-  const net = Math.round((closedPnl - fees + (cursor.residual || 0)) * 1e6) / 1e6;
+  const fundingPnl = freshFunding.reduce((s, x) => s + x.usdc, 0);
+  const net = Math.round((closedPnl - fees + fundingPnl + (cursor.residual || 0)) * 1e6) / 1e6;
   const closes = fresh.filter((f) => Number(f.closedPnl || 0) !== 0).length;
+  const maxFundingTime = freshFunding.reduce((m, x) => Math.max(m, x.time), cursor.lastFundingTime || 0);
 
   const summary = {
     ok: true,
@@ -97,26 +115,27 @@ async function main() {
     closes,
     closedPnl: Math.round(closedPnl * 1e6) / 1e6,
     fees: Math.round(fees * 1e6) / 1e6,
+    fundingPnl: Math.round(fundingPnl * 1e6) / 1e6,
     netRealizedUsd: net,
   };
 
-  if (mode === 'peek' || fresh.length === 0) {
+  if (mode === 'peek' || (fresh.length === 0 && freshFunding.length === 0)) {
     summary.settled = false;
     process.stdout.write(JSON.stringify(summary) + '\n');
     return;
   }
 
-  // advance time cursor over all consumed fills
-  const maxTime = Math.max(cursor.lastTime, ...fresh.map((f) => f.time));
+  // advance time cursors over all consumed fills + funding
+  const maxTime = Math.max(cursor.lastTime, ...(fresh.length ? fresh.map((f) => f.time) : [cursor.lastTime]));
   const tidsAtMax = fills.filter((f) => f.time === maxTime).map((f) => f.tid);
   let residual = net;
   let settled = false;
   if (Math.abs(net) >= DUST) {
-    settle(net, `auto-settle: ${fresh.length} fills, ${closes} closes`);
+    settle(net, `auto-settle: ${fresh.length} fills, ${closes} closes, funding ${summary.fundingPnl}`);
     residual = 0;
     settled = true;
   }
-  saveCursor({ lastTime: maxTime, lastTids: tidsAtMax, residual });
+  saveCursor({ lastTime: maxTime, lastTids: tidsAtMax, residual, lastFundingTime: maxFundingTime });
   summary.settled = settled;
   summary.carriedResidual = residual;
   process.stdout.write(JSON.stringify(summary) + '\n');

--- a/scripts/erc8004_register.js
+++ b/scripts/erc8004_register.js
@@ -110,7 +110,9 @@ function statsForCard(state) {
 }
 
 function agentCard(state, managed, child) {
-  const name = child ? child.name : 'Gclaw';
+  // A stable display name (set once in metabolism.json `name`) is preserved
+  // across every beacon — beaconing must never clobber a custom identity.
+  const name = child ? child.name : (state.name || 'Gclaw');
   const bornAt = child ? child.born_at : state.born_at || 'genesis';
   const g = genome(name, bornAt);
   const lineage = child


### PR DESCRIPTION
- **Funding booked** (assune-rc4): autosettle nets HL `userFunding` for the managed wallet into the settle with its own cursor. Caught ~$0.09 of previously-unbooked funding on the live agent.
- **Verified leaderboard** (assune-ejl): the public board ranks by **HyperLiquid equity read live from the public API** (managed wallet is in the card) — independently checkable, not spoofable. Self-reporting agents can no longer fake their way to #1; shows a `✓ verified` badge. Verified live: Zephlith "$211.355 verified" at #1.
- **Name preservation**: beaconing no longer overwrites a custom display name (surfaced when a peer's 'Blaq Ceaser G' got reset to 'Gclaw').

Closes assune-rc4, assune-ejl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)