### PR TITLE
Soft trailing stop (profit lock-in under managed custody)

### DIFF
--- a/references/safety.md
+++ b/references/safety.md
@@ -11,6 +11,7 @@ network is adversarial. The controls below exist so a creature can't be drained.
 | **Prompt injection → fund exit** | The heartbeat runs unattended (`bypassPermissions`) and reads untrusted text (peer cards, family bus, market data, gene-pool metadata). It denies every tool that can move funds to an arbitrary destination: `transfer_native`, `transfer_token`, `execute_bridge`, `perp_withdraw`, `hl_swap_collateral`, sells. Legit funding is done by deterministic scripts (`autofund`, `gmac_buy`) with **hard-coded destinations** — never by the model. |
 | **Key exposure** | The control private key is used only for local `ethers.Wallet` signing; it is never logged or sent. Wallet files (`*-wallet.json`) and secrets (`~/.gclaw/env`) are gitignored. |
 | **Runaway losses** | A portfolio **circuit breaker** halts new entries (never blocks closing) when equity falls ≥25% from its high-water mark or there are ≥3 open positions. Per-trade risk is also capped (5% / 2% in survive) with a mandatory stop. |
+| **Giving back profit** | Managed custody can't move an exchange stop (the backend only attaches tp/sl to an executing order). A **soft trailing stop** (`autotrail.js`, run each heartbeat) instead closes a position once it's in profit and trails ≥0.6% off its high-water mark — floored at break-even, so it only ever closes green. The hard exchange SL set at open stays as the between-heartbeat catastrophic floor. (A true exchange-side trailing stop needs the GDEX backend to expose standalone trigger orders — see assune-6tk.) |
 
 ## Health alerting
 

--- a/scripts/autotrail.js
+++ b/scripts/autotrail.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Gclaw soft trailing stop — locks in profit the only way managed custody allows.
+ *
+ * HyperLiquid managed custody can't place a standalone stop TRIGGER (the backend
+ * only attaches tp/sl to an executing order), so a stop can't be moved on the
+ * exchange. Instead this runs each heartbeat: it tracks each position's
+ * high-water mark and, once the trade is in profit, arms a soft stop at
+ * break-even that trails up. If price falls back to it, the position is closed
+ * (a market close DOES work). The hard exchange SL set at open stays as the
+ * between-heartbeat catastrophic floor — this only ever closes in profit.
+ *
+ *   node autotrail.js run    # enforce: close any position whose soft-stop is hit
+ *   node autotrail.js peek   # report soft-stops without closing
+ *
+ * Env: GDEX_SKILL_DIR, GCLAW_WALLET, GCLAW_HOME.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const https = require('node:https');
+const { execFileSync } = require('node:child_process');
+
+const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
+const SKILL_DIR = path.join(os.homedir(), '.claude', 'skills', 'gclaw', 'scripts');
+const TRAILS_PATH = path.join(GCLAW_HOME, 'trails.json');
+
+const ARM_PROFIT_PCT = 1.0;  // arm the trail once a position is +1% in profit
+const TRAIL_PCT = 0.6;       // then trail the soft-stop 0.6% below the high-water mark
+
+const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+
+function allMids() {
+  return new Promise((resolve) => {
+    const body = JSON.stringify({ type: 'allMids' });
+    const req = https.request('https://api.hyperliquid.xyz/info',
+      { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': body.length } },
+      (res) => { let b = ''; res.on('data', (c) => { b += c; }); res.on('end', () => { try { resolve(JSON.parse(b)); } catch { resolve({}); } }); });
+    req.on('error', () => resolve({}));
+    req.write(body); req.end();
+  });
+}
+
+function positions() {
+  const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status'], { encoding: 'utf8', timeout: 90000 });
+  return JSON.parse(out.trim().split('\n').pop()).positions || [];
+}
+
+function softStop(dir, entry, hw) {
+  // Floored at break-even, trails by TRAIL_PCT below (long) / above (short) the high-water.
+  const trailed = dir > 0 ? hw * (1 - TRAIL_PCT / 100) : hw * (1 + TRAIL_PCT / 100);
+  return dir > 0 ? Math.max(entry, trailed) : Math.min(entry, trailed);
+}
+
+function closePosition(coin) {
+  const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'close', '--coin', coin], { encoding: 'utf8', timeout: 90000 });
+  return JSON.parse(out.trim().split('\n').pop());
+}
+
+async function main() {
+  const mode = process.argv[2] || 'run';
+  const mids = await allMids();
+  const trails = readJson(TRAILS_PATH, {});
+  const pos = positions();
+  const live = new Set(pos.map((p) => p.coin));
+  for (const k of Object.keys(trails)) if (!live.has(k)) delete trails[k];  // forget closed
+
+  const report = [];
+  for (const p of pos) {
+    const dir = Number(p.size) > 0 ? 1 : -1;
+    const entry = Number(p.entryPx);
+    const mark = Number(mids[p.coin]) || (entry + Number(p.unrealizedPnl || 0) / Number(p.size));
+    const t = trails[p.coin] || { hw: mark, armed: false };
+    t.hw = dir > 0 ? Math.max(t.hw, mark) : Math.min(t.hw, mark);
+    const profitPct = ((mark - entry) / entry) * 100 * dir;
+    if (profitPct >= ARM_PROFIT_PCT) t.armed = true;
+    const stop = softStop(dir, entry, t.hw);
+    const hit = t.armed && (dir > 0 ? mark <= stop : mark >= stop);
+    trails[p.coin] = t;
+    const row = { coin: p.coin, dir: dir > 0 ? 'long' : 'short', mark, entry, hw: t.hw,
+      armed: t.armed, softStop: Number(stop.toFixed(4)), profitPct: Number(profitPct.toFixed(2)), hit };
+    if (hit && mode === 'run') { row.closed = closePosition(p.coin); delete trails[p.coin]; }
+    report.push(row);
+  }
+  fs.writeFileSync(TRAILS_PATH, JSON.stringify(trails, null, 2) + '\n');
+  process.stdout.write(JSON.stringify({ ok: true, mode, trailed: report }) + '\n');
+}
+
+main().catch((e) => { process.stdout.write(JSON.stringify({ ok: false, error: e.message || String(e) }) + '\n'); process.exit(1); });

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -47,7 +47,11 @@ cd "$HOME"
 # Auto-fund: convert any ETH sent to Arbitrum into USDC + deposit to HL.
 [[ -f "$SKILL_DIR/scripts/autofund.js" ]] &&
   echo "$(ts) autofund: $(node "$SKILL_DIR/scripts/autofund.js" run 2>&1)" >>"$LOG" || true
-# Deterministic auto-settle: book realized PnL from any closes (TP/SL) before the agent decides.
+# Soft trailing stop: lock in profit on any position that trailed off its
+# high-water mark (managed custody can't move an exchange stop; this closes).
+[[ -f "$SKILL_DIR/scripts/autotrail.js" ]] &&
+  echo "$(ts) autotrail: $(node "$SKILL_DIR/scripts/autotrail.js" run 2>&1)" >>"$LOG" || true
+# Deterministic auto-settle: book realized PnL from any closes (TP/SL/trail) before the agent decides.
 [[ -f "$SKILL_DIR/scripts/autosettle.js" ]] &&
   echo "$(ts) autosettle: $(node "$SKILL_DIR/scripts/autosettle.js" run 2>&1)" >>"$LOG" || true
 


### PR DESCRIPTION
Delivers stop-trailing the only way managed custody allows.

**Why not a real exchange stop:** the live test proved the managed backend can't place a standalone stop *trigger* (`hl_create_order` only attaches tp/sl to an executing order; we don't hold the managed key). True exchange-side trailing needs the GDEX backend — filed as **assune-6tk**.

**What this does:** `autotrail.js` runs each heartbeat — tracks each position's high-water mark, and once +1% in profit, arms a soft stop that trails 0.6% below the high-water (floored at break-even). If price falls back to it, it closes (market close works). The hard exchange SL from open stays as the between-heartbeat floor, so this **only ever closes in profit**. Wired before autosettle so closes are booked.

Logic unit-tested (long/short, arm threshold, break-even floor). Closes assune-7zr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)