### PR TITLE
P3: genome/name decouple + automatic royalty attribution

### DIFF
--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -134,6 +134,15 @@ async function main() {
     settle(net, `auto-settle: ${fresh.length} fills, ${closes} closes, funding ${summary.fundingPnl}`);
     residual = 0;
     settled = true;
+    // Auto-attribute each closing fill to its technique's author (royalty) — works
+    // regardless of how the trade was opened (forge --execute OR the model via MCP).
+    for (const f of fresh.filter((x) => Number(x.closedPnl || 0) !== 0)) {
+      try {
+        execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'forge.py'),
+          'royalty', '--coin', String(f.coin), '--pnl', String(f.closedPnl), '--auto'],
+        { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'ignore', 'ignore'] });
+      } catch { /* attribution is best-effort */ }
+    }
   }
   saveCursor({ lastTime: maxTime, lastTids: tidsAtMax, residual, lastFundingTime: maxFundingTime });
   summary.settled = settled;

--- a/scripts/erc8004_register.js
+++ b/scripts/erc8004_register.js
@@ -121,11 +121,15 @@ function statsForCard(state) {
 }
 
 function agentCard(state, managed, child) {
-  // A stable display name (set once in metabolism.json `name`) is preserved
-  // across every beacon — beaconing must never clobber a custom identity.
+  // Display name (set once in metabolism.json `name`) is preserved across every
+  // beacon. The GENOME is seeded separately from a stable value ('Gclaw' for the
+  // main creature, the child's name for offspring) + born_at, so renaming a
+  // creature never mutates its species/traits — and existing genomes are
+  // unchanged (they were always seeded from 'Gclaw' + born_at).
   const name = child ? child.name : (state.name || 'Gclaw');
   const bornAt = child ? child.born_at : state.born_at || 'genesis';
-  const g = genome(name, bornAt);
+  const genomeSeed = child ? child.name : 'Gclaw';
+  const g = genome(genomeSeed, bornAt);
   const lineage = child
     ? { parentAgentId: state.onchain_identity?.agentId ?? null, role: child.role, mutation: child.mutation }
     : {};

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -771,9 +771,18 @@ def cmd_royalty(args: argparse.Namespace) -> dict[str, Any]:
     """
     pending = load_pending()
     rec = pending.get(args.coin)
+    # Fall back to the adopted technique trading this coin, so trades opened via
+    # MCP (not `run --execute`, which sets pending) still credit the right author.
+    fallback = None
     if not rec and not args.ref:
-        die(f"no pending forge trade on {args.coin} — pass --ref <author>/<id> to attribute manually")
-    ref = (rec or {}).get("ref") or args.ref
+        adopted = next((e for e in load_style().get("adopted", []) if e.get("coin") == args.coin), None)
+        if adopted:
+            fallback, _ = royalty_ref(load_technique(adopted["id"]))
+    ref = (rec or {}).get("ref") or args.ref or fallback
+    if not ref:
+        if getattr(args, "auto", False):
+            return {"ok": True, "attributed": None, "note": f"no technique attributable to {args.coin}"}
+        die(f"no pending or adopted technique on {args.coin} — pass --ref <author>/<id> to attribute manually")
     author = ref.split("/", 1)[0] if "/" in ref else ref
     adopter = agent_id()
     pnl = float(args.pnl)
@@ -1203,6 +1212,7 @@ def build_parser() -> argparse.ArgumentParser:
     ro.add_argument("--coin", required=True)
     ro.add_argument("--pnl", required=True, help="realized PnL in USD (signed)")
     ro.add_argument("--ref", default=None, help="<author>/<id> if no pending trade")
+    ro.add_argument("--auto", action="store_true", help="no-op (don't error) when nothing is attributable")
     ro.set_defaults(fn=cmd_royalty)
 
     rep = sub.add_parser("reputation", help="author reputation from the royalty ledger")


### PR DESCRIPTION
- **assune-lr4** — the genome was derived from the display name, so renaming a creature changed its species/traits. Now seeded from a stable value + born_at; display name is purely cosmetic. Existing genomes unchanged (Zephlith still `b4753e982d2c`).
- **assune-ume** — royalty attribution was LLM-dependent and only worked for `run --execute` trades. Now `autosettle` auto-attributes each closing fill on settle, and `cmd_royalty` falls back to the adopted technique for the coin — so MCP-opened peer-technique trades credit the author too. Verified: a TSLA close attributes to `stock-meanrev`; unadopted coins no-op.

Closes assune-lr4, assune-ume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)