### PR TITLE
Harden autotrail against transient status failures

### DIFF
--- a/scripts/autotrail.js
+++ b/scripts/autotrail.js
@@ -44,8 +44,14 @@ function allMids() {
 }
 
 function positions() {
-  const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status'], { encoding: 'utf8', timeout: 90000 });
-  return JSON.parse(out.trim().split('\n').pop()).positions || [];
+  // Best-effort: a transient status failure means "nothing to trail this cycle"
+  // (the hard exchange SL still protects), never an error that noise-spams the log.
+  try {
+    const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status'], { encoding: 'utf8', timeout: 90000 });
+    return JSON.parse(out.trim().split('\n').pop()).positions || [];
+  } catch {
+    return [];
+  }
 }
 
 function softStop(dir, entry, hw) {


### PR DESCRIPTION
autotrail's positions() threw when hl_perp status had a transient hiccup. Now returns [] (nothing to trail; the hard exchange SL still protects) — no log noise. Surfaced by heartbeat #48.