### PR TITLE
Fix: agent must know xyz stock perps trade 24/7 (the edge)

### DIFF
--- a/dna/HEARTBEAT.md
+++ b/dna/HEARTBEAT.md
@@ -15,7 +15,10 @@ the family only when balance and edge justify it.
    USDC balance; buyingPower = spot `total − hold`). The MCP clearinghouse `accountValue` /
    `withdrawable` is only margin already committed — it reads ~$0 even when fully funded, so
    NEVER treat it as free capital. If `buyingPower` ≥ the min notional, you have money to trade.
-3. **Read the tape**: `get_hl_meta_and_asset_ctxs` (mark, funding, OI). For events: `hl_outcomes`.
+3. **Read the tape**: `get_hl_meta_and_asset_ctxs` (mark, funding, OI) — but this covers only the
+   DEFAULT dex. For the 24/7 `xyz` stock/commodity perps use `node scripts/forge_data.js features
+   --coins xyz:SPCX,xyz:NVDA,xyz:TSLA` — a 0 from the default tools is NOT a closed market. For
+   events: `hl_outcomes`.
 4. **Act** only on a clear thesis, sized by the risk limit and free `buyingPower`, always with TP/SL. At most one or two moves.
 5. **Settle** realized PnL into the metabolism. Charge a discovery cost if the cycle did heavy intel.
 6. **Evolve** if a goodwill threshold is newly crossed.

--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -8,11 +8,21 @@ GMAC with real realized profit, then grow it without ever risking extinction.
 1. **HyperLiquid perpetuals (USDC, default dex)** — the core engine. Start with majors
    (BTC, ETH, SOL) and expand to any **liquid** asset from `getHlAllAssets` as edge appears.
 2. **HIP-3 outcome / event markets** — the defined-risk satellite for asymmetric, near-dated bets.
-3. **Builder/HIP-3 perps** (stocks `xyz:NVDA`/`xyz:TSLA`/`xyz:SPCX`, oil, etc.) — the `xyz` dex is
-   **USDC-collateralized, 24h** (no collateral swap needed) and is verified working: opens fill and
-   honor the leverage passed (3x isolated, live-confirmed). Pass the coin lowercase-prefixed and read
-   the position with `dex: "xyz"`. Lead with default-dex USDC majors; these are the same mechanism
-   with a dex-prefixed coin.
+3. **Builder/HIP-3 perps** (stocks `xyz:NVDA`/`xyz:TSLA`/`xyz:SPCX`, oil, gold, etc.) — the `xyz`
+   dex is **USDC-collateralized and trades 24/7/365** (no collateral swap needed), verified working:
+   opens fill and honor the leverage passed (3x isolated, live-confirmed). Pass the coin
+   lowercase-prefixed and read the position with `dex: "xyz"`.
+
+   **This is your EDGE.** When traditional equity markets are *closed* (nights, weekends, holidays)
+   these perps keep trading — SpaceX alone runs ~$800M/day around the clock. Closed TradFi means
+   *less competition*, not no market. **NEVER conclude "markets are closed" for `xyz`.**
+
+   ⚠️ **Read xyz prices the dex-aware way.** The MCP tape tools (`get_hl_meta_and_asset_ctxs`,
+   `get_all_mid_prices`, `get_mark_price`) cover only the *default* dex and return **0 / nothing for
+   `xyz:*`** — that is a wrong read, NOT a closed market. Get live xyz mark/funding/vol with
+   `node scripts/forge_data.js features --coins xyz:SPCX,xyz:NVDA,xyz:TSLA` (queries
+   `metaAndAssetCtxs` with `dex:"xyz"`). The forge already uses this for its xyz signals — **trust a
+   forge xyz signal; do not override it with a default-dex price check.**
 
 No memecoins. No unlisted low-liquidity tokens. Liquidity and a legible thesis gate every name.
 


### PR DESCRIPTION
A heartbeat concluded 'markets are closed' for the xyz stock dex on a Thursday night and skipped the forge's xyz signals. **Wrong** — HyperLiquid xyz perps trade **24/7/365** (verified live right now: SPCX $182.68 mark, **$874M/day volume**, OI 1.48M; TSLA candles flowing). That round-the-clock trading is the edge vs traditional markets.

Root cause: the MCP tape tools (`get_hl_meta_and_asset_ctxs`/`get_all_mid_prices`/`get_mark_price`) take no dex param and return 0 for `xyz:*`, which the model misread as a closed market.

Fix (DNA): xyz is 24/7/365 and the edge; closed TradFi = less competition, not no market; **never** conclude 'closed' for xyz; read live xyz data via `forge_data.js features --coins` (dex-aware, queries metaAndAssetCtxs with dex:'xyz'); trust the forge's xyz signals. Runtime DNA synced so it takes effect next heartbeat.