### PR TITLE
Lead with the creature's name, not the Gclaw template

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -405,8 +405,11 @@ def leaderboard_html(h: Path) -> str:
 
 
 def render_html(state: dict[str, Any], identity: str, journal: list, messages: list) -> str:
-    name = "Gclaw"
-    g = genome(name, state.get("born_at", "genesis"))
+    # Lead with the creature's own name (defaults to its unique species, not the
+    # generic 'Gclaw' template). Genome stays seeded from a stable value so the
+    # name never mutates the species/traits.
+    g = genome("Gclaw", state.get("born_at", "genesis"))
+    name = state.get("name") or g["species"]
     mode = state.get("mode", "unknown").upper()
     mode_hue = {"THRIVE": 140, "SURVIVE": 40, "HIBERNATE": 220}.get(mode, 200)
     gmac = state.get("gmac_balance", 0)

--- a/scripts/erc8004_register.js
+++ b/scripts/erc8004_register.js
@@ -126,10 +126,12 @@ function agentCard(state, managed, child) {
   // main creature, the child's name for offspring) + born_at, so renaming a
   // creature never mutates its species/traits — and existing genomes are
   // unchanged (they were always seeded from 'Gclaw' + born_at).
-  const name = child ? child.name : (state.name || 'Gclaw');
   const bornAt = child ? child.born_at : state.born_at || 'genesis';
   const genomeSeed = child ? child.name : 'Gclaw';
   const g = genome(genomeSeed, bornAt);
+  // Lead with the creature's own name: a custom `name` if set, else its unique
+  // species (Zephlith, Lyxmire, …) — never the generic 'Gclaw' template.
+  const name = child ? child.name : (state.name || g.species);
   const lineage = child
     ? { parentAgentId: state.onchain_identity?.agentId ?? null, role: child.role, mutation: child.mutation }
     : {};


### PR DESCRIPTION
Dashboard + onchain card now show the creature's unique name (custom `state.name`, else its species) instead of the generic 'Gclaw'. Genome stays seeded from a stable value so the name never mutates the creature. Verified: #55624 reads 'Zephlith' on the dashboard and in the onchain roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)