### PR TITLE
Dopamine loop: creature texts wins in-voice + achievements wall

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -404,6 +404,29 @@ def leaderboard_html(h: Path) -> str:
             f'<th>GMAC</th><th>equity</th></tr>{"".join(rows)}</table>')
 
 
+def achievements_html(state: dict[str, Any]) -> str:
+    """Badge wall — unlocked milestones + the next target, the chase-the-next loop."""
+    gw = float(state.get("goodwill", 0) or 0)
+    hb = int(state.get("heartbeats", 0) or 0)
+    gmac = float(state.get("gmac_balance", 0) or 0)
+    seed = float(state.get("seed", 1000) or 1000)
+    kids = len(state.get("children", []))
+    streak = int(load_json(home() / "celebrations.json", {}).get("winStreak", 0) or 0)
+    items = []
+    for t in (10, 25, 50, 100, 200, 500, 1000):
+        tag = {50: " ·Replicate", 100: " ·Recode", 1000: " ·Max lev"}.get(t, "")
+        items.append(("⭐", f"GW {t}{tag}", gw >= t))
+    for t in (100, 250, 500, 1000):
+        items.append(("🫀", f"{t} beats", hb >= t))
+    items += [("🜂", "Above seed", gmac > seed), ("🧬", "First child", kids > 0),
+              ("🔥", f"{streak}-win streak" if streak >= 3 else "Win streak", streak >= 3)]
+    badges = "".join(
+        f'<span class="badge {"on" if u else "off"}">{e} {html.escape(lbl)}</span>' for e, lbl, u in items)
+    nxt = next((t for t in (10, 25, 50, 100, 200, 500, 1000) if gw < t), None)
+    prog = f'<div class="muted" style="margin-top:10px">Next badge → ⭐ goodwill {gw:g}/{nxt}</div>' if nxt else ""
+    return f'<div class="badges">{badges}</div>{prog}'
+
+
 def render_html(state: dict[str, Any], identity: str, journal: list, messages: list) -> str:
     # Lead with the creature's own name (defaults to its unique species, not the
     # generic 'Gclaw' template). Genome stays seeded from a stable value so the
@@ -439,6 +462,7 @@ def render_html(state: dict[str, Any], identity: str, journal: list, messages: l
         positions=positions_html(home()),
         roster=roster_html(home()),
         leaderboard=leaderboard_html(home()),
+        achievements=achievements_html(state),
         topup=topup_html(home()),
         recodes=state.get("recodes", 0),
         children=len(state.get("children", [])),
@@ -509,6 +533,10 @@ h1{{margin:0;font-size:26px;letter-spacing:.5px}}h2{{font-size:13px;text-transfo
 .trait{{display:grid;grid-template-columns:90px 1fr 30px;align-items:center;gap:8px;margin:7px 0;font-size:13px}}.trait b{{text-align:right}}
 ul{{list-style:none;margin:0;padding:0}}.family li,.events li{{padding:7px 0;border-bottom:1px solid var(--line);font-size:13px}}
 .pill{{display:inline-block;background:#1d2a47;color:#9db4ff;padding:1px 8px;border-radius:999px;font-size:11px;margin-right:6px}}
+.badges{{display:flex;flex-wrap:wrap;gap:8px}}
+.badge{{font-size:12px;padding:4px 10px;border-radius:999px;border:1px solid var(--line)}}
+.badge.on{{background:#13351f;border-color:#1f6b46;color:#7CFFB2}}
+.badge.off{{background:#0c1322;color:var(--muted);opacity:.55}}
 .muted{{color:var(--muted);font-size:12px}}.foot{{text-align:center;color:var(--muted);font-size:11px;margin-top:18px}}
 .lev{{display:flex;justify-content:space-between;padding:5px 0;border-bottom:1px solid var(--line);font-size:13px;color:var(--muted)}}
 .lev b{{color:var(--muted)}}.lev.on{{color:var(--ink)}}.lev.on b{{color:#7CFFB2;font-size:15px}}.lev.locked{{opacity:.5}}
@@ -546,6 +574,7 @@ ul{{list-style:none;margin:0;padding:0}}.family li,.events li{{padding:7px 0;bor
     <div class="card decent"><h2>👥 Family roster · onchain (Base)</h2>{roster}</div>
     <div class="card decent"><h2>🏆 Leaderboard</h2>{leaderboard}</div>
   </div>
+  <div class="card" style="margin-top:18px"><h2>🏅 Achievements</h2>{achievements}</div>
   <div class="card decent" style="margin-top:18px"><h2>💰 Top up your bot</h2><div class="topup">{topup}</div></div>
   <div class="grid2" style="margin-top:18px">
     <div class="card"><h2>Life events</h2>{events}</div>

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -83,3 +83,7 @@ fi
 # tripped breaker, low funds) when GCLAW_ALERT_WEBHOOK is set. No-ops otherwise.
 [[ -f "$SKILL_DIR/scripts/notify.js" ]] &&
   echo "$(ts) alerts: $(node "$SKILL_DIR/scripts/notify.js" check 2>&1)" >>"$LOG" || true
+# Celebrate the GOOD moments — text wins / milestones / streaks in the creature's
+# own voice so the human keeps coming back. No-ops without a webhook.
+[[ -f "$SKILL_DIR/scripts/notify.js" ]] &&
+  echo "$(ts) celebrate: $(node "$SKILL_DIR/scripts/notify.js" celebrate 2>&1)" >>"$LOG" || true

--- a/scripts/notify.js
+++ b/scripts/notify.js
@@ -35,15 +35,83 @@ async function post(url, body, headers) {
   });
 }
 
-async function send(level, message) {
-  const text = `🜃 Gclaw #${agentId()} [${level.toUpperCase()}] ${message}`;
-  const out = { ok: true, sent: [] };
+const readJsonl = (p) => { try { return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l)); } catch { return []; } };
+
+// The creature's own voice — so it texts you in character, not as a robot.
+function soul() {
+  const p = readJson(path.join(GCLAW_HOME, 'dna', 'persona.json'), {});
+  const m = readJson(path.join(GCLAW_HOME, 'metabolism.json'), {});
+  return { name: m.name || p.species || p.name || 'Gclaw', sigil: p.sigil || '🜂',
+    catchphrase: p.catchphrase || '', archetype: p.archetype || '' };
+}
+function voiced(msg, big) {
+  const s = soul();
+  return `${s.sigil} ${s.name}: ${msg}` + (big && s.catchphrase ? `  —  “${s.catchphrase}”` : '');
+}
+
+async function deliver(text) {
+  const sent = [];
   const webhook = process.env.GCLAW_ALERT_WEBHOOK;
-  if (webhook) { await post(webhook, { text, content: text, level, message }); out.sent.push('webhook'); }
+  if (webhook) { await post(webhook, { text, content: text }); sent.push('webhook'); }
   const tg = process.env.GCLAW_TELEGRAM_TOKEN, chat = process.env.GCLAW_TELEGRAM_CHAT;
-  if (tg && chat) { await post(`https://api.telegram.org/bot${tg}/sendMessage`, { chat_id: chat, text }); out.sent.push('telegram'); }
-  if (!out.sent.length) out.skip = 'no GCLAW_ALERT_WEBHOOK / telegram configured';
-  return out;
+  if (tg && chat) { await post(`https://api.telegram.org/bot${tg}/sendMessage`, { chat_id: chat, text }); sent.push('telegram'); }
+  return sent;
+}
+
+async function send(level, message) {
+  const sent = await deliver(`🜃 ${soul().name} #${agentId()} [${level.toUpperCase()}] ${message}`);
+  return sent.length ? { ok: true, sent } : { ok: true, sent: [], skip: 'no GCLAW_ALERT_WEBHOOK / telegram configured' };
+}
+
+const GW_TIERS = [[10, ''], [25, ''], [50, ' — ready to REPLICATE 🧬'], [100, ' — can self-recode'],
+  [200, ''], [500, ''], [1000, ' — MAX leverage unlocked ⚡']];
+const HB_TIERS = [100, 250, 500, 1000, 2500, 5000];
+const STREAK_TIERS = [3, 5, 10, 25];
+
+// The dopamine loop: each heartbeat, detect the GOOD moments and text them in the
+// creature's voice — wins, streaks, milestones, records, evolutions, climbs. First
+// run baselines (no retroactive spam); thereafter it fires only on new events.
+async function celebrate() {
+  const meta = readJson(path.join(GCLAW_HOME, 'metabolism.json'), {});
+  const lb = readJson(path.join(GCLAW_HOME, 'leaderboard.json'), {});
+  const rank = (lb.ranked || []).find((e) => e.self)?.rank ?? null;
+  const stPath = path.join(GCLAW_HOME, 'celebrations.json');
+  const first = !fs.existsSync(stPath);
+  const settles = readJsonl(path.join(GCLAW_HOME, 'journal.jsonl')).filter((e) => e.event === 'settle');
+  const lastSettleTs = settles.length ? Math.max(...settles.map((s) => new Date(s.ts).getTime())) : 0;
+  const kids = (meta.children || []).length;
+  const st = readJson(stPath, {});
+  if (first) {  // baseline: remember where we are, celebrate nothing retroactively
+    fs.writeFileSync(stPath, JSON.stringify({ unlocked: {}, lastSettleTs, winStreak: 0,
+      lastGoodwill: meta.goodwill || 0, lastRank: rank, lastHeartbeats: meta.heartbeats || 0,
+      lastChildren: kids, lastRecodes: meta.recodes || 0 }, null, 2));
+    return { ok: true, initialized: true };
+  }
+  const fired = [];
+  const fire = async (key, msg, big) => { if (st.unlocked[key]) return; if (key.startsWith('once:')) st.unlocked[key] = new Date().toISOString(); const v = voiced(msg, big); fired.push(v); await deliver(v); };
+
+  for (const s of settles.filter((e) => new Date(e.ts).getTime() > (st.lastSettleTs || 0))) {
+    if (Number(s.pnl) > 0.01) { st.winStreak = (st.winStreak || 0) + 1; await fire(`win:${s.ts}`, `booked +$${Number(s.pnl).toFixed(2)} 💚  ⭐ goodwill ${s.goodwill}`, false); } else if (Number(s.pnl) < -0.01) { st.winStreak = 0; }
+    if (Number(s.gmac_buyback_usd) > 0.01) await fire(`burn:${s.ts}`, `bought & burned $${Number(s.gmac_buyback_usd).toFixed(2)} of $GMAC 🔥`, false);
+  }
+  st.lastSettleTs = lastSettleTs;
+  for (const n of STREAK_TIERS) if (st.winStreak === n) await fire(`streak:${n}:${Math.floor((meta.heartbeats || 0) / 100)}`, `🔥 ${n} wins in a row`, true);
+  const gw = meta.goodwill || 0;
+  for (const [tier, label] of GW_TIERS) if (gw >= tier && (st.lastGoodwill || 0) < tier) await fire(`once:gw${tier}`, `hit ⭐ goodwill ${tier}${label}`, true);
+  st.lastGoodwill = gw;
+  const seed = meta.seed || 1000;
+  if ((meta.gmac_balance || 0) > seed) await fire('once:seedback', `clawed back above its ${seed} GMAC seed — in the black`, true);
+  const hb = meta.heartbeats || 0;
+  for (const n of HB_TIERS) if (hb >= n && (st.lastHeartbeats || 0) < n) await fire(`once:hb${n}`, `${n} heartbeats and still alive`, true);
+  st.lastHeartbeats = hb;
+  if (kids > (st.lastChildren || 0)) { const c = meta.children[kids - 1] || {}; await fire(`child:${c.name}`, `spawned a child — ${c.name || '?'} 🧬`, true); }
+  st.lastChildren = kids;
+  if ((meta.recodes || 0) > (st.lastRecodes || 0)) await fire(`recode:${meta.recodes}`, `rewrote its own code (recode #${meta.recodes}) 🛠️`, true);
+  st.lastRecodes = meta.recodes || 0;
+  if (rank != null && st.lastRank != null && rank < st.lastRank) { fired.push(voiced(`climbed to #${rank} on the family leaderboard 📈`, false)); await deliver(fired[fired.length - 1]); }
+  if (rank != null) st.lastRank = rank;
+  fs.writeFileSync(stPath, JSON.stringify(st, null, 2) + '\n');
+  return { ok: true, fired };
 }
 
 function conditions() {
@@ -76,7 +144,8 @@ async function main() {
   let out;
   if (cmd === 'send') out = await send(process.argv[3] || 'info', process.argv.slice(4).join(' '));
   else if (cmd === 'check') out = await check();
-  else out = { ok: false, error: 'usage: notify.js <send <level> <msg> | check>' };
+  else if (cmd === 'celebrate') out = await celebrate();
+  else out = { ok: false, error: 'usage: notify.js <send <level> <msg> | check | celebrate>' };
   process.stdout.write(JSON.stringify(out) + '\n');
 }
 


### PR DESCRIPTION
Reverse-engineer suggestions #1 + #2 from the engagement audit.

**#1 — the creature texts you.** `notify.js celebrate` detects the good moments each heartbeat — wins, $GMAC burns, win streaks, goodwill/heartbeat/seed milestones, evolutions, leaderboard climbs — and pushes them **in the creature's own voice + catchphrase** (🜂 Zephlith: booked +$0.14 💚 … 'Still here. Still trading.'). The notify layer used to speak only on failures; now it celebrates. First run baselines (no retroactive spam); delivers via the existing webhook/Telegram env, no-ops without it.

**#2 — micro-achievements.** A 🏅 Achievements badge wall on the dashboard (unlocked vs locked + the next target) fills the dead zone between goodwill milestones with a constant chase-the-next loop.

Verified live: fires the +$0.14 win and the $0.01 burn in-voice; milestone format appends the catchphrase; dashboard panel renders. Needs `GCLAW_ALERT_WEBHOOK` or `GCLAW_TELEGRAM_TOKEN`+`_CHAT` in ~/.gclaw/env to actually reach a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)