### PR TITLE
Global predictors ladder (onchain-aggregated, cross-creature)

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -427,10 +427,34 @@ def achievements_html(state: dict[str, Any]) -> str:
     return f'<div class="badges">{badges}</div>{prog}'
 
 
+def global_predictors(h: Path) -> list[dict]:
+    """Sum every predictor across every creature — peers from their onchain cards,
+    self from the freshest local tallies — into the one global ladder."""
+    agg: dict[str, dict] = {}
+
+    def add(by: str, c: int, t: int) -> None:
+        e = agg.setdefault(str(by), {"correct": 0, "total": 0, "creatures": 0})
+        e["correct"] += c
+        e["total"] += t
+        e["creatures"] += 1 if t > 0 else 0
+
+    for a in load_json(h / "peers_roster.json", {}).get("roster", []):
+        if a.get("self"):
+            continue  # self folded from fresh local tallies below
+        for p in a.get("predictors", []):
+            add(p.get("by", "?"), p.get("c", 0), p.get("t", 0))
+    for by, v in load_json(h / "predictions" / "predictors.json", {}).items():
+        add(by, v.get("correct", 0), v.get("total", 0))
+    board = [
+        {"by": by, "acc": round(e["correct"] / e["total"] * 100) if e["total"] else 0, **e}
+        for by, e in agg.items() if e["total"] > 0
+    ]
+    return sorted(board, key=lambda e: (-e["acc"], -e["correct"]))
+
+
 def predictions_html(h: Path) -> str:
-    """The free 'Call it' game — the open round + the predictors leaderboard."""
+    """The free 'Call it' game — the open round + the GLOBAL predictors ladder."""
     rounds = load_json(h / "predictions" / "rounds.json", {})
-    preds = load_json(h / "predictions" / "predictors.json", {})
     parts = []
     open_r = [r for r in rounds.values() if r.get("status") == "open"]
     if open_r:
@@ -440,16 +464,16 @@ def predictions_html(h: Path) -> str:
                          f'<span class="muted">round {r["id"]}</span></div>')
     else:
         parts.append('<p class="muted">No open round — one opens when the creature opens a trade.</p>')
-    board = sorted(
-        ({"by": k, "acc": round(v["correct"] / v["total"] * 100) if v.get("total") else 0, **v} for k, v in preds.items()),
-        key=lambda e: (-e["acc"], -e.get("correct", 0)))
+    board = global_predictors(h)
     if board:
         rows = "".join(
             f'<tr><td>{i + 1}</td><td>{html.escape(e["by"])}</td><td>{e["acc"]}%</td>'
-            f'<td>{e.get("correct", 0)}/{e.get("total", 0)}</td><td>{e.get("streak", 0)}🔥</td></tr>'
-            for i, e in enumerate(board[:8]))
+            f'<td>{e["correct"]}/{e["total"]}</td><td>{e["creatures"]}</td></tr>'
+            for i, e in enumerate(board[:10]))
         parts.append(f'<table class="lb" style="margin-top:10px"><tr><th>#</th><th>predictor</th>'
-                     f'<th>acc</th><th>record</th><th>streak</th></tr>{rows}</table>')
+                     f'<th>acc</th><th>record</th><th>souls</th></tr>{rows}</table>'
+                     f'<p class="muted" style="margin-top:6px">🌐 Global — every predictor across every creature, '
+                     f'aggregated from onchain cards.</p>')
     else:
         parts.append('<p class="muted" style="margin-top:8px">No predictors yet — be the first to call it. '
                      'Free, no stakes; calls are anchored onchain so nobody can cheat.</p>')

--- a/scripts/erc8004_register.js
+++ b/scripts/erc8004_register.js
@@ -100,6 +100,17 @@ function predictionsRoot() {
   } catch { return null; }
 }
 
+function predictorTallies() {
+  // This creature attests the record of predictors who called on ITS trades
+  // (resolved against HyperLiquid's fills). Published onchain so the decentralized
+  // site can aggregate every predictor across every creature into ONE global ladder.
+  try {
+    const p = JSON.parse(fs.readFileSync(path.join(GCLAW_HOME, 'predictions', 'predictors.json'), 'utf8'));
+    return Object.entries(p).map(([by, v]) => ({ by: String(by).slice(0, 42), c: v.correct || 0, t: v.total || 0 }))
+      .filter((e) => e.t > 0).sort((a, b) => b.c - a.c).slice(0, 20);
+  } catch { return []; }
+}
+
 function publishedTechniques() {
   // Compact advert of this creature's proven, IPFS-pinned techniques so peers
   // discover the family's edges straight from chain. Metadata only (+ a cid);
@@ -160,7 +171,7 @@ function agentCard(state, managed, child) {
       goodwill: child ? 0 : state.goodwill ?? 0,
       controlWallet: JSON.parse(fs.readFileSync(WALLET_PATH, 'utf8')).control.address,
       managedHlWallet: managed,
-      ...(child ? {} : { stats: statsForCard(state), peers: knownPeers(), published: publishedTechniques(), predictions: predictionsRoot() }),
+      ...(child ? {} : { stats: statsForCard(state), peers: knownPeers(), published: publishedTechniques(), predictions: predictionsRoot(), predictors: predictorTallies() }),
       ...lineage,
     },
   };

--- a/scripts/peers.js
+++ b/scripts/peers.js
@@ -58,6 +58,7 @@ async function readAgent(id) {
   const owner = ownerRaw && ownerRaw !== '0x' ? '0x' + ownerRaw.slice(-40) : null;
   return { id: Number(id), name: meta.name || null, owner, image: meta.image || null,
     stats: meta['x-gclaw']?.stats || null,  // live standings beacon, read straight from chain
+    predictors: meta['x-gclaw']?.predictors || [],  // who called this creature's trades right — for the global ladder
     published: meta['x-gclaw']?.published || [],  // proven techniques advertised for discovery
     isGclaw: typeof meta.description === 'string' && meta.description.includes(SIGNATURE) };
 }

--- a/scripts/predict.js
+++ b/scripts/predict.js
@@ -12,7 +12,8 @@
  *   node predict.js call --round <id> --pick TP|SL --by <handle> [--sig <sig>]
  *   node predict.js resolve            # score rounds whose trade has closed
  *   node predict.js root               # keccak root of open rounds+calls (for the beacon)
- *   node predict.js leaderboard        # rank predictors by accuracy + streak
+ *   node predict.js leaderboard        # rank this creature's predictors
+ *   node predict.js global             # GLOBAL ladder — every predictor across every creature
  *
  * Pure clout: points are never money, never redeemable, never purchasable — so
  * it is not gambling and holds no funds. Env: GDEX_SKILL_DIR, GCLAW_WALLET, GCLAW_HOME.
@@ -166,6 +167,25 @@ function cmdLeaderboard() {
   return { ok: true, predictors: board };
 }
 
+// The GLOBAL ladder: sum every predictor's record across EVERY creature — peers
+// read from their onchain cards (peers_roster.json), self from the freshest local
+// tallies. A handle that called on several creatures aggregates into one rank, so
+// the board ranks humans community-wide, not per-creature.
+function cmdGlobal() {
+  const agg = {};
+  const add = (by, c, t) => { const k = String(by); const e = agg[k] || { correct: 0, total: 0, creatures: 0 }; e.correct += c; e.total += t; e.creatures += t > 0 ? 1 : 0; agg[k] = e; };
+  for (const a of readJson(path.join(GCLAW_HOME, 'peers_roster.json'), {}).roster || []) {
+    if (a.self) continue; // self folded from fresh local tallies below (avoids double-count + lag)
+    for (const p of a.predictors || []) add(p.by, p.c || 0, p.t || 0);
+  }
+  for (const [by, v] of Object.entries(readJson(predictorsPath(), {}))) add(by, v.correct || 0, v.total || 0);
+  const board = Object.entries(agg).map(([by, e]) => ({ by, correct: e.correct, total: e.total, creatures: e.creatures,
+    accuracy: e.total ? Math.round((e.correct / e.total) * 100) : 0 }))
+    .filter((e) => e.total > 0).sort((a, b) => b.accuracy - a.accuracy || b.correct - a.correct);
+  board.forEach((e, i) => { e.rank = i + 1; });
+  return { ok: true, global: true, predictors: board };
+}
+
 function parseArgs(a) { const o = {}; for (let i = 0; i < a.length; i += 1) if (a[i].startsWith('--')) { o[a[i].slice(2)] = a[i + 1] && !a[i + 1].startsWith('--') ? a[i += 1] : true; } return o; }
 
 async function main() {
@@ -177,7 +197,8 @@ async function main() {
   else if (cmd === 'resolve') out = await cmdResolve(args);
   else if (cmd === 'root') out = { ok: true, ...readJson(path.join(DIR, 'root.json'), { root: writeRoot() }) };
   else if (cmd === 'leaderboard') out = cmdLeaderboard();
-  else out = { ok: false, error: 'usage: predict.js <open|call|resolve|root|leaderboard>' };
+  else if (cmd === 'global') out = cmdGlobal();
+  else out = { ok: false, error: 'usage: predict.js <open|call|resolve|root|leaderboard|global>' };
   process.stdout.write(JSON.stringify(out, null, 2) + '\n');
 }
 


### PR DESCRIPTION
Each person predicts via **their own private bot**, but climbs **one community-wide ladder**.

**Trustless aggregation:** each creature attests the record of predictors who called on *its* trades (resolved against HyperLiquid's fills) and publishes those tallies in its ERC-8004 card. The global ladder = sum every predictor across every creature's **onchain** card. No one can inflate their own score — each creature only reports its own trades' outcomes, and a handle active on several creatures merges into one rank.

- `erc8004_register.js`: `x-gclaw.predictors` published onchain.
- `peers.js`: reads tallies from every creature's chain card.
- `predict.js global`: cross-creature aggregator.
- `dashboard.py`: 🎯 panel shows the global ladder (acc · record · #souls).

Verified: alice's 2/2 (self) + 3/4 (peer) → 5/6 across 2 souls ranks correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)