### PR TITLE
Fix cron node resolution (Telegram poll was failing)

### DIFF
--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -17,8 +17,10 @@ SKILL_DIR="${GCLAW_SKILL_DIR:-$HOME/.claude/skills/gclaw}"
 mkdir -p "$GCLAW_HOME"
 
 # cron has a minimal PATH; ensure node + user bins resolve. Adjust if needed.
-NODE_BIN="$(command -v node 2>/dev/null || true)"
-export PATH="$HOME/.local/bin:${NODE_BIN%/node}:/usr/local/bin:/usr/bin:/bin:$PATH"
+NODE_DIR="$(command -v node 2>/dev/null || true)"; NODE_DIR="${NODE_DIR%/node}"
+# cron's bare env has no nvm on PATH, so fall back to the newest nvm node bin.
+[[ -z "$NODE_DIR" ]] && NODE_DIR="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
+export PATH="$NODE_DIR:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 # Load runtime secrets (PINATA_JWT for IPFS publishing, etc.) — gitignored, never committed.
 if [[ -f "$GCLAW_HOME/env" ]]; then set -a; . "$GCLAW_HOME/env"; set +a; fi

--- a/scripts/predict_bot.sh
+++ b/scripts/predict_bot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Telegram poll for the Call it game — invoked by cron every 2 min for near-real-time
+# call capture. Sources runtime secrets (token); cron has a minimal PATH so resolve node.
+#
+# Install:   cp scripts/predict_bot.sh "$HOME/.gclaw/predict_bot.sh" && chmod +x "$_"
+#            ( crontab -l 2>/dev/null; echo "*/2 * * * * \$HOME/.gclaw/predict_bot.sh >> \$HOME/.gclaw/predict_bot.log 2>&1" ) | crontab -
+set -euo pipefail
+GCLAW_HOME="${GCLAW_HOME:-$HOME/.gclaw}"
+SKILL_DIR="${GCLAW_SKILL_DIR:-$HOME/.claude/skills/gclaw}"
+NODE_DIR="$(command -v node 2>/dev/null || true)"; NODE_DIR="${NODE_DIR%/node}"
+# cron's bare env has no nvm on PATH, so fall back to the newest nvm node bin.
+[[ -z "$NODE_DIR" ]] && NODE_DIR="$(ls -d "$HOME"/.nvm/versions/node/*/bin 2>/dev/null | sort -V | tail -1)"
+export PATH="$NODE_DIR:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+[[ -f "$GCLAW_HOME/env" ]] && { set -a; . "$GCLAW_HOME/env"; set +a; }
+exec node "$SKILL_DIR/scripts/predict_bot.js" poll


### PR DESCRIPTION
cron's bare PATH made `command -v node` return empty, so the `*/2` predict_bot poll failed with `node: not found` and Telegram TP/SL calls were never captured. Falls back to the newest nvm node bin when `command -v` misses, in the heartbeat and a tracked `predict_bot.sh` wrapper. Verified in a simulated cron env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)