### PR TITLE
Trading intelligence stack: perception, regime, sizing, memory

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -51,14 +51,37 @@ there to earn the right to auto-trade it. Don't tunnel on BTC/ETH/SOL: stocks mo
 - Keep dry powder: never deploy the whole treasury; the survival buffer is sacred.
 - Mind funding: don't pay rich funding to sit on a crowded side.
 
-## Operating loop (per heartbeat)
-1. Check open exposure first (`get_perp_positions`, `get_hl_clearinghouse_state`).
-2. Manage existing positions before opening new ones — move stops to break-even on winners, cut losers at the stop.
-3. Read the tape: `get_hl_meta_and_asset_ctxs` (mark, funding, OI), `get_mark_price`.
-4. Only open when there is a clear thesis and the setup quality is real. Otherwise gather intel and wait.
-5. For events: scan `hl_outcomes` for near-dated markets with real volume and a price that diverges from your estimate.
-6. Size from the risk limit, not conviction. Open with TP/SL. State the thesis first.
-7. On close, settle realized PnL into metabolism.
+## Operating loop (per heartbeat) — intelligence-driven
+
+You have a perception + risk stack. **Use it; do not trade on a raw price glance.**
+
+1. **Exposure first** (`get_perp_positions`, `get_hl_clearinghouse_state`). Manage open
+   positions before opening new ones — stops to break-even on winners, cut losers at the stop.
+   If you hold correlated longs (intel `btc_corr` > 0.8) all the same way as a `trend_down`
+   regime, reduce — never stack correlated risk into the trend.
+2. **Read the regime FIRST** — `node scripts/intel.js scan` (also cached at `~/.gclaw/intel.json`
+   each heartbeat). Per coin you get `regime` (trend_up / trend_down / range / chop),
+   `efficiency`, `rsi`, `atr_pct`, `bb_z`, `funding_z`, `ema_stack`, `btc_corr`, `flow_pressure`,
+   `tradeable`.
+3. **The chop gate — DO NOT open a coin whose `regime` is `chop`** (`tradeable:false`). That is
+   exactly where the historical losses came from. In `range`, fade `bb_z` extremes
+   (mean-reversion). In `trend_up`/`trend_down`, trade WITH `ema_stack` (momentum) — never fight it.
+   Extreme `funding_z` (|z| > 1.5) flags a crowded book → expect a squeeze against the crowd.
+4. **Demand proven, regime-matched edge** — `node scripts/memory.py query --regime <regime>` ranks
+   your techniques by expectancy *in this regime*. Open only if a technique shows `edge_real: true`
+   for the current regime, **or** (cold start, no history) the intel gives a high-conviction,
+   regime-aligned setup. A coin-flip signal (confidence < 0.6) is not a setup — wait.
+5. **Size with the risk brain, never by gut** —
+   `node scripts/sizing.py size --equity <E> --price <P> --atr-pct <atr_pct> --win-rate <w>
+   --payoff <b> --goodwill <g> --confidence <c>` (pull `--win-rate`/`--payoff` from
+   `memory.py expectancy --technique <t> --regime <r>`). Open with exactly the returned `notional`,
+   `size`, and ATR-based stop. This caps any single trade's risk to a fixed fraction of equity —
+   no trade can dominate the P&L again. Write the intended risk to `~/.gclaw/open_risk.json`
+   (`{"<coin>": <risk_usd>}`) so the close records a true R-multiple.
+6. For events: scan `hl_outcomes` for near-dated markets with real volume and a price that diverges
+   from your estimate.
+7. On close, settle (auto). Each close is auto-recorded to the trade-memory with its regime, so your
+   expectancy estimates — and every future sizing decision — sharpen with every trade.
 
 ## Mode behavior
 - **THRIVE:** normal operation; perps + selective outcome bets.

--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -29,6 +29,20 @@ const SDK = require(path.join(GDEX_DIR, 'dist'));
 const CURSOR_PATH = path.join(GCLAW_HOME, 'autosettle.json');
 const DUST = 0.01; // carry remainders below 1 cent rather than spam tiny settles
 
+const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+
+// One regime read per settle for the coins that just closed — tags each memory
+// record with the market conditions it happened in.
+function fetchRegimes(coins) {
+  if (!coins.length) return {};
+  try {
+    const out = execFileSync('node', [path.join(__dirname, 'intel.js'), 'regime', '--coins', coins.join(',')],
+      { env: { ...process.env, GCLAW_HOME }, timeout: 30000 }).toString();
+    const r = JSON.parse(out.slice(out.indexOf('{'))).regimes || {};
+    return Object.fromEntries(Object.entries(r).map(([k, v]) => [k, v && v.regime]));
+  } catch { return {}; }
+}
+
 function loadCursor() {
   if (!fs.existsSync(CURSOR_PATH)) return { lastTime: 0, lastTids: [], residual: 0 };
   return JSON.parse(fs.readFileSync(CURSOR_PATH, 'utf8'));
@@ -134,14 +148,30 @@ async function main() {
     settle(net, `auto-settle: ${fresh.length} fills, ${closes} closes, funding ${summary.fundingPnl}`);
     residual = 0;
     settled = true;
-    // Auto-attribute each closing fill to its technique's author (royalty) — works
-    // regardless of how the trade was opened (forge --execute OR the model via MCP).
-    for (const f of fresh.filter((x) => Number(x.closedPnl || 0) !== 0)) {
+    const closers = fresh.filter((x) => Number(x.closedPnl || 0) !== 0);
+    const regimes = fetchRegimes([...new Set(closers.map((f) => f.coin))]);
+    const openRisk = readJson(path.join(GCLAW_HOME, 'open_risk.json'), {});
+    // Auto-attribute each closing fill to its technique's author (royalty) AND
+    // record the outcome to the trade-memory (technique x regime -> R) so the agent
+    // learns which techniques actually work in which conditions.
+    for (const f of closers) {
+      let technique = 'unknown';
       try {
-        execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'forge.py'),
+        const out = execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'forge.py'),
           'royalty', '--coin', String(f.coin), '--pnl', String(f.closedPnl), '--auto'],
-        { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'ignore', 'ignore'] });
+        { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'pipe', 'ignore'] });
+        technique = JSON.parse(out.toString()).technique || 'unknown';
       } catch { /* attribution is best-effort */ }
+      try {
+        const notional = Math.abs(Number(f.sz || 0)) * Number(f.px || 0);
+        const risk = openRisk[f.coin] || notional * 0.015 || 0.25; // sized risk, else 1.5%-stop estimate
+        const side = String(f.dir || '').includes('Short') ? 'short' : 'long';
+        execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'memory.py'),
+          'record', '--coin', String(f.coin), '--technique', String(technique),
+          '--regime', regimes[f.coin] || 'unknown', '--side', side,
+          '--pnl', String(f.closedPnl), '--risk', String(risk)],
+        { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'ignore', 'ignore'] });
+      } catch { /* memory record is best-effort */ }
     }
   }
   saveCursor({ lastTime: maxTime, lastTids: tidsAtMax, residual, lastFundingTime: maxFundingTime });

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -56,6 +56,10 @@ cd "$HOME"
 # Deterministic auto-settle: book realized PnL from any closes (TP/SL/trail) before the agent decides.
 [[ -f "$SKILL_DIR/scripts/autosettle.js" ]] &&
   echo "$(ts) autosettle: $(node "$SKILL_DIR/scripts/autosettle.js" run 2>&1)" >>"$LOG" || true
+# Perception: scan the market into a regime + feature read the agent and dashboard use.
+[[ -f "$SKILL_DIR/scripts/intel.js" ]] &&
+  node "$SKILL_DIR/scripts/intel.js" scan >"$GCLAW_HOME/intel.json" 2>>"$LOG" &&
+  echo "$(ts) intel: $(uv run --no-project python3 -c 'import json;d=json.load(open("'"$GCLAW_HOME"'/intel.json"));print({k:(v["regime"] if v else None) for k,v in d.get("intel",{}).items()})' 2>/dev/null)" >>"$LOG" || true
 
 # Anti-drain: the heartbeat runs unattended with bypassPermissions, and reads
 # untrusted text (peer cards, family bus, market data, gene-pool metadata) that

--- a/scripts/intel.js
+++ b/scripts/intel.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * intel.js — the agent's perception + regime engine.
+ *
+ * Turns raw HyperLiquid candles + funding into a rich, decision-grade feature
+ * vector per coin: trend (EMA stack + slope), momentum (RSI), volatility (ATR%,
+ * realized vol), mean-reversion (Bollinger z-score), funding z-score, open-interest
+ * delta, BTC correlation, a candle-based flow-pressure proxy, and — the headline —
+ * a REGIME label (trend_up / trend_down / range / chop) so techniques know when to
+ * act and when to sit out. Pure read of the public API; holds no funds.
+ *
+ *   node intel.js scan --coins BTC,ETH,SOL      # full intel per coin (default majors)
+ *   node intel.js regime --coins SOL            # just the regime labels
+ *
+ * Env: GCLAW_HOME (caches OI for delta), HL_INFO_URL (defaults to mainnet).
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const https = require('node:https');
+
+const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
+const INFO_URL = process.env.HL_INFO_URL || 'https://api.hyperliquid.xyz/info';
+const HOUR = 3600_000;
+
+function info(body) {
+  return new Promise((resolve) => {
+    const d = JSON.stringify(body);
+    const r = https.request(INFO_URL, { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(d) }, timeout: 20000 },
+      (x) => { let b = ''; x.on('data', (c) => { b += c; }); x.on('end', () => { try { resolve(JSON.parse(b)); } catch { resolve(null); } }); });
+    r.on('error', () => resolve(null)); r.on('timeout', () => { r.destroy(); resolve(null); });
+    r.write(d); r.end();
+  });
+}
+
+// --- math primitives -------------------------------------------------------
+const mean = (a) => (a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0);
+const stdev = (a) => { if (a.length < 2) return 0; const m = mean(a); return Math.sqrt(mean(a.map((x) => (x - m) ** 2))); };
+const sma = (a, n) => mean(a.slice(-n));
+
+function ema(values, n) {
+  if (!values.length) return 0;
+  const k = 2 / (n + 1);
+  let e = values[0];
+  for (let i = 1; i < values.length; i += 1) e = values[i] * k + e * (1 - k);
+  return e;
+}
+
+function rsi(closes, n = 14) {
+  if (closes.length <= n) return 50;
+  let gain = 0; let loss = 0;
+  for (let i = closes.length - n; i < closes.length; i += 1) {
+    const d = closes[i] - closes[i - 1];
+    if (d >= 0) gain += d; else loss -= d;
+  }
+  if (loss === 0) return 100;
+  const rs = (gain / n) / (loss / n);
+  return 100 - 100 / (1 + rs);
+}
+
+function atrPct(candles, n = 14) {
+  if (candles.length <= n) return 0;
+  const trs = [];
+  for (let i = candles.length - n; i < candles.length; i += 1) {
+    const c = candles[i]; const prev = candles[i - 1];
+    trs.push(Math.max(c.h - c.l, Math.abs(c.h - prev.c), Math.abs(c.l - prev.c)));
+  }
+  const last = candles[candles.length - 1].c;
+  return last ? (mean(trs) / last) * 100 : 0;
+}
+
+// Kaufman efficiency ratio: net move / total path. ~1 = clean trend, ~0 = chop.
+function efficiencyRatio(closes, n = 20) {
+  if (closes.length <= n) return 0;
+  const slice = closes.slice(-n - 1);
+  const net = Math.abs(slice[slice.length - 1] - slice[0]);
+  let path = 0;
+  for (let i = 1; i < slice.length; i += 1) path += Math.abs(slice[i] - slice[i - 1]);
+  return path ? net / path : 0;
+}
+
+function correlation(a, b) {
+  const n = Math.min(a.length, b.length);
+  if (n < 3) return 0;
+  const x = a.slice(-n); const y = b.slice(-n);
+  const mx = mean(x); const my = mean(y);
+  let num = 0; let dx = 0; let dy = 0;
+  for (let i = 0; i < n; i += 1) { num += (x[i] - mx) * (y[i] - my); dx += (x[i] - mx) ** 2; dy += (y[i] - my) ** 2; }
+  return dx && dy ? num / Math.sqrt(dx * dy) : 0;
+}
+
+const returns = (closes) => closes.slice(1).map((c, i) => (closes[i] ? (c - closes[i]) / closes[i] : 0));
+
+// --- data ------------------------------------------------------------------
+async function candles(coin, interval, limit) {
+  const now = Date.now();
+  const from = now - HOUR * (limit + 2);
+  const raw = await info({ type: 'candleSnapshot', req: { coin, interval, startTime: from, endTime: now } });
+  return (raw || []).map((k) => ({ t: k.t, o: +k.o, h: +k.h, l: +k.l, c: +k.c, v: +k.v }));
+}
+
+async function fundingZ(coin) {
+  const hist = await info({ type: 'fundingHistory', coin, startTime: Date.now() - HOUR * 24 * 14 });
+  if (!Array.isArray(hist) || hist.length < 5) return { funding_z: 0, funding_now: 0 };
+  const rates = hist.map((h) => Number(h.fundingRate));
+  const now = rates[rates.length - 1]; const sd = stdev(rates);
+  return { funding_z: sd ? (now - mean(rates)) / sd : 0, funding_now: now };
+}
+
+function classifyRegime(f) {
+  // trend when price moves efficiently; chop when it thrashes at high vol; else range.
+  if (f.atr_pct > 4 && f.efficiency < 0.3) return 'chop';
+  if (f.efficiency >= 0.4) return f.ema_stack >= 0 ? 'trend_up' : 'trend_down';
+  if (f.efficiency < 0.25) return 'range';
+  return f.ema_stack > 0 ? 'trend_up' : (f.ema_stack < 0 ? 'trend_down' : 'range');
+}
+
+async function coinIntel(coin, ctx, btcReturns) {
+  const c1 = await candles(coin, '1h', 120);
+  if (c1.length < 30) return null;
+  const closes = c1.map((k) => k.c);
+  const e9 = ema(closes.slice(-40), 9); const e21 = ema(closes.slice(-60), 21); const e50 = ema(closes, 50);
+  const ema_stack = (e9 > e21 ? 1 : -1) + (e21 > e50 ? 1 : -1); // -2..+2
+  const sd20 = stdev(closes.slice(-20));
+  const bb_z = sd20 ? (closes[closes.length - 1] - sma(closes, 20)) / sd20 : 0;
+  const last = c1[c1.length - 1];
+  const flow_pressure = last.h > last.l ? ((last.c - last.l) / (last.h - last.l) - 0.5) * 2 : 0; // -1..+1
+  const fz = await fundingZ(coin);
+  const f = {
+    coin,
+    price: closes[closes.length - 1],
+    ema_stack,
+    ema_slope_pct: e50 ? ((e9 - e50) / e50) * 100 : 0,
+    rsi: Math.round(rsi(closes) * 10) / 10,
+    atr_pct: Math.round(atrPct(c1) * 100) / 100,
+    realized_vol_pct: Math.round(stdev(returns(closes.slice(-24))) * 100 * 100) / 100,
+    bb_z: Math.round(bb_z * 100) / 100,
+    ...fz,
+    funding_z: Math.round(fz.funding_z * 100) / 100,
+    open_interest: ctx ? Number(ctx.openInterest) : null,
+    premium: ctx ? Number(ctx.premium) : null,
+    btc_corr: coin === 'BTC' ? 1 : Math.round(correlation(returns(closes.slice(-24)), btcReturns) * 100) / 100,
+    flow_pressure: Math.round(flow_pressure * 100) / 100,
+  };
+  f.efficiency = Math.round(efficiencyRatio(closes) * 100) / 100;
+  f.regime = classifyRegime(f);
+  f.tradeable = f.regime !== 'chop';
+  return f;
+}
+
+async function scan(coins) {
+  const ctxResp = await info({ type: 'metaAndAssetCtxs' });
+  const ctxByName = new Map();
+  if (Array.isArray(ctxResp) && ctxResp[0]?.universe) ctxResp[0].universe.forEach((u, i) => ctxByName.set(u.name, ctxResp[1][i]));
+  const btc = await candles('BTC', '1h', 48);
+  const btcReturns = returns(btc.map((k) => k.c).slice(-24));
+  const out = {};
+  for (const coin of coins) out[coin] = await coinIntel(coin, ctxByName.get(coin), btcReturns);
+  return out;
+}
+
+function parseArgs(a) { const o = {}; for (let i = 0; i < a.length; i += 1) if (a[i].startsWith('--')) { o[a[i].slice(2)] = a[i + 1] && !a[i + 1].startsWith('--') ? a[i += 1] : true; } return o; }
+
+async function main() {
+  const cmd = process.argv[2] || 'scan';
+  const args = parseArgs(process.argv.slice(3));
+  const coins = String(args.coins || 'BTC,ETH,SOL').split(',').map((s) => s.trim()).filter(Boolean);
+  fs.mkdirSync(GCLAW_HOME, { recursive: true });
+  const intel = await scan(coins);
+  if (cmd === 'regime') {
+    const out = Object.fromEntries(Object.entries(intel).map(([k, v]) => [k, v ? { regime: v.regime, efficiency: v.efficiency, tradeable: v.tradeable } : null]));
+    process.stdout.write(JSON.stringify({ ok: true, regimes: out }) + '\n');
+  } else {
+    process.stdout.write(JSON.stringify({ ok: true, intel }) + '\n');
+  }
+}
+
+main().catch((e) => { process.stdout.write(JSON.stringify({ ok: false, error: e.message }) + '\n'); process.exit(1); });

--- a/scripts/memory.py
+++ b/scripts/memory.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""memory.py — the agent's trade-memory and regime-conditional expectancy store.
+
+The right-sized "knowledge graph": every closed trade is one record linking
+technique x coin x regime x feature-snapshot -> outcome (R-multiple). From that
+relational memory the agent answers the question that fixes entry quality:
+
+    "In conditions like RIGHT NOW (this regime), which of my techniques actually
+     has positive, statistically-real expectancy — and how should I size it?"
+
+Expectancy is reported with a bootstrap confidence interval, so a technique that
+is merely lucky (CI straddles zero) is not treated as an edge. File-based and
+transparent: one JSONL line per trade at $GCLAW_HOME/memory.jsonl.
+
+    memory.py record --coin SOL --technique stock-meanrev --regime range \
+                     --side long --pnl 0.84 --risk 0.84
+    memory.py expectancy --technique stock-meanrev [--regime range]
+    memory.py query --regime range          # rank techniques for this regime
+    memory.py summary                        # per (technique,regime) table (for the swarm)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def home() -> Path:
+    return Path(os.environ.get("GCLAW_HOME", str(Path.home() / ".gclaw")))
+
+
+def store() -> Path:
+    return home() / "memory.jsonl"
+
+
+def load() -> list[dict]:
+    p = store()
+    if not p.exists():
+        return []
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+def record(args: argparse.Namespace) -> dict:
+    """Append one closed-trade outcome. R-multiple normalises pnl by risk taken."""
+    risk = abs(args.risk) if args.risk else 0.0
+    r_multiple = (args.pnl / risk) if risk else 0.0
+    row = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "coin": args.coin,
+        "technique": args.technique,
+        "regime": args.regime,
+        "side": args.side,
+        "pnl": round(args.pnl, 4),
+        "risk": round(risk, 4),
+        "r": round(r_multiple, 3),
+    }
+    home().mkdir(parents=True, exist_ok=True)
+    with store().open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+    return {"ok": True, "recorded": row, "total": len(load())}
+
+
+def _bootstrap_ci(rs: list[float], iters: int = 2000) -> tuple[float, float]:
+    """95% CI on the mean R via bootstrap resampling — is the edge real or luck?"""
+    if len(rs) < 3:
+        return (0.0, 0.0)
+    means = []
+    n = len(rs)
+    for _ in range(iters):
+        means.append(sum(rs[int(random.random() * n)] for _ in range(n)) / n)
+    means.sort()
+    return (round(means[int(0.025 * iters)], 3), round(means[int(0.975 * iters)], 3))
+
+
+def _stats(rows: list[dict]) -> dict:
+    if not rows:
+        return {"trades": 0}
+    rs = [row["r"] for row in rows]
+    wins = [r for r in rs if r > 0]
+    pnl = sum(row["pnl"] for row in rows)
+    lo, hi = _bootstrap_ci(rs)
+    avg_win = (sum(wins) / len(wins)) if wins else 0.0
+    losses = [abs(r) for r in rs if r < 0]
+    avg_loss = (sum(losses) / len(losses)) if losses else 0.0
+    return {
+        "trades": len(rs),
+        "win_rate": round(len(wins) / len(rs), 3),
+        "expectancy_r": round(sum(rs) / len(rs), 3),
+        "ci95": [lo, hi],
+        "edge_real": lo > 0,  # whole CI above zero = a real edge, not luck
+        "payoff": round(avg_win / avg_loss, 2) if avg_loss else (avg_win or 0.0),
+        "pnl_usd": round(pnl, 2),
+    }
+
+
+def _filter(rows: list[dict], technique: str | None, regime: str | None) -> list[dict]:
+    return [r for r in rows
+            if (technique is None or r.get("technique") == technique)
+            and (regime is None or r.get("regime") == regime)]
+
+
+def expectancy(args: argparse.Namespace) -> dict:
+    rows = _filter(load(), args.technique, args.regime)
+    return {"ok": True, "technique": args.technique, "regime": args.regime, **_stats(rows)}
+
+
+def query(args: argparse.Namespace) -> dict:
+    """Rank techniques by expectancy in a regime — the 'what should I trade now' call."""
+    rows = _filter(load(), None, args.regime)
+    by_tech: dict[str, list[dict]] = {}
+    for row in rows:
+        by_tech.setdefault(row["technique"], []).append(row)
+    ranked = [{"technique": t, **_stats(rs)} for t, rs in by_tech.items()]
+    ranked.sort(key=lambda e: (e.get("edge_real", False), e.get("expectancy_r", 0)), reverse=True)
+    return {"ok": True, "regime": args.regime, "techniques": ranked}
+
+
+def summary(_args: argparse.Namespace) -> dict:
+    """Compact per-(technique, regime) expectancy table — published to the swarm."""
+    rows = load()
+    cells: dict[str, list[dict]] = {}
+    for row in rows:
+        cells.setdefault(f'{row["technique"]}|{row.get("regime", "?")}', []).append(row)
+    table = []
+    for key, rs in cells.items():
+        tech, regime = key.split("|", 1)
+        s = _stats(rs)
+        table.append({"technique": tech, "regime": regime, "trades": s["trades"],
+                      "expectancy_r": s["expectancy_r"], "edge_real": s["edge_real"]})
+    table.sort(key=lambda e: e["expectancy_r"], reverse=True)
+    return {"ok": True, "table": table}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="trade-memory + regime-conditional expectancy")
+    sub = p.add_subparsers(dest="command", required=True)
+    r = sub.add_parser("record")
+    r.add_argument("--coin", required=True)
+    r.add_argument("--technique", required=True)
+    r.add_argument("--regime", required=True)
+    r.add_argument("--side", default="long")
+    r.add_argument("--pnl", type=float, required=True)
+    r.add_argument("--risk", type=float, default=0.0)
+    e = sub.add_parser("expectancy")
+    e.add_argument("--technique", required=True)
+    e.add_argument("--regime")
+    q = sub.add_parser("query")
+    q.add_argument("--regime", required=True)
+    sub.add_parser("summary")
+    args = p.parse_args()
+    fn = {"record": record, "expectancy": expectancy, "query": query, "summary": summary}[args.command]
+    print(json.dumps(fn(args), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sizing.py
+++ b/scripts/sizing.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""sizing.py — the risk brain: vol-targeted position sizing with fractional Kelly.
+
+Two jobs, both aimed at the diagnosed failures:
+
+1. Vol-target — risk a fixed fraction of equity per trade, and derive the position
+   size from an ATR-based stop so a wide-stop trade isn't automatically a big-loss
+   trade. One trade can never again be 72% of the damage.
+2. Fractional Kelly — scale that risk fraction by the technique's proven edge
+   (win-rate + payoff). Proven edges get sized up; weak/coin-flip signals get sized
+   down to the floor or skipped.
+
+Pure arithmetic, no I/O, holds nothing. The $11 HyperLiquid min notional and the
+goodwill leverage ladder are enforced.
+
+    sizing.py size --equity 211 --price 68.9 --atr-pct 1.14 \
+                   --win-rate 0.55 --payoff 1.5 --goodwill 3 [--confidence 0.7]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+MIN_NOTIONAL = 11.0
+BASE_RISK_PCT = 0.005  # risk 0.5% of equity per trade at full Kelly confidence
+KELLY_FRACTION = 0.25  # quarter-Kelly — survival agent, not a degen
+STOP_ATR_MULT = 1.6    # stop sits 1.6 ATR from entry
+# goodwill → max leverage (mirrors the trading DNA ladder)
+LEVERAGE_LADDER = [(0, 2), (25, 3), (50, 5), (100, 8), (200, 12), (500, 20)]
+
+
+def leverage_cap(goodwill: float) -> int:
+    cap = 2
+    for threshold, lev in LEVERAGE_LADDER:
+        if goodwill >= threshold:
+            cap = lev
+    return cap
+
+
+def kelly_fraction(win_rate: float, payoff: float) -> float:
+    """Edge as a fraction of bankroll: f* = W - (1-W)/b, then quarter it."""
+    if payoff <= 0:
+        return 0.0
+    full = win_rate - (1 - win_rate) / payoff
+    return max(0.0, full) * KELLY_FRACTION
+
+
+def size_trade(equity: float, price: float, atr_pct: float, win_rate: float,
+               payoff: float, goodwill: float, confidence: float) -> dict:
+    """Return the position size, stop, and risk for one trade."""
+    stop_pct = max(STOP_ATR_MULT * atr_pct, 0.8) / 100  # never tighter than 0.8%
+    # risk fraction: base, scaled by Kelly edge and the signal's confidence.
+    edge = kelly_fraction(win_rate, payoff)
+    # an unknown/zero edge still gets a tiny probe; a real edge scales toward base.
+    risk_pct = min(BASE_RISK_PCT, max(0.0015, edge)) * max(0.3, min(1.0, confidence))
+    risk_usd = equity * risk_pct
+    notional = risk_usd / stop_pct
+    cap_notional = equity * leverage_cap(goodwill)
+    notional = max(MIN_NOTIONAL, min(notional, cap_notional))
+    # recompute realized risk after the min/cap clamp so the report is honest.
+    realized_risk = notional * stop_pct
+    size = notional / price if price else 0
+    return {
+        "ok": True,
+        "notional_usd": round(notional, 2),
+        "size": round(size, 6),
+        "stop_distance_pct": round(stop_pct * 100, 2),
+        "stop_long": round(price * (1 - stop_pct), 4),
+        "stop_short": round(price * (1 + stop_pct), 4),
+        "risk_usd": round(realized_risk, 2),
+        "risk_pct_equity": round(realized_risk / equity * 100, 2) if equity else 0,
+        "kelly_edge": round(edge, 4),
+        "leverage_cap": leverage_cap(goodwill),
+        "clamped_to_min": notional <= MIN_NOTIONAL + 1e-9,
+        "note": "sized to risk a fixed fraction of equity; size falls out of the ATR stop",
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="vol-targeted + Kelly position sizing")
+    p.add_argument("command", choices=["size"])
+    p.add_argument("--equity", type=float, required=True)
+    p.add_argument("--price", type=float, required=True)
+    p.add_argument("--atr-pct", type=float, required=True)
+    p.add_argument("--win-rate", type=float, default=0.5)
+    p.add_argument("--payoff", type=float, default=1.5)
+    p.add_argument("--goodwill", type=float, default=0)
+    p.add_argument("--confidence", type=float, default=0.6)
+    a = p.parse_args()
+    out = size_trade(a.equity, a.price, a.atr_pct, a.win_rate, a.payoff, a.goodwill, a.confidence)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Three engines targeting the two diagnosed failures (chop losses, one oversized loss), plus the right-sized knowledge-graph layer.

- **intel.js** — perception + **regime classifier** (trend/range/**chop**) with rich features (EMA stack, RSI, ATR%, realized vol, Bollinger z, funding z-score, BTC corr, flow pressure) from HL's public API.
- **sizing.py** — vol-targeted + fractional-Kelly sizing. Risk a fixed % of equity off an ATR stop; proven edges sized up, coin-flips to the $11 floor. Prevents one trade being 72% of losses.
- **memory.py** — regime-conditional expectancy with a **bootstrap CI** (`edge_real` only when the CI clears zero), so luck isn't mistaken for edge. The right-sized 'knowledge graph'.

Wiring: autosettle records every close (`technique × regime → R`); heartbeat scans intel each cycle; the trading DNA gates on regime (**no trading in chop**), demands regime-matched proven edge, and sizes via the risk brain. All engines tested live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)