### PR TITLE
Swarm collective graph + market-intelligence dashboard panel

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -71,6 +71,13 @@ You have a perception + risk stack. **Use it; do not trade on a raw price glance
    your techniques by expectancy *in this regime*. Open only if a technique shows `edge_real: true`
    for the current regime, **or** (cold start, no history) the intel gives a high-conviction,
    regime-aligned setup. A coin-flip signal (confidence < 0.6) is not a setup — wait.
+   - **Lean on the family.** `node scripts/memory.py swarm` pools every creature's onchain-published
+     `technique × regime → edge` into one collective table — a result proven across many creatures is
+     stronger than your own small sample. Prefer techniques with collective `edge_real`.
+   - **Smart-money (HUMINT).** Consult `get_hl_top_traders_by_pnl` (GDEX MCP) for how the
+     provably-profitable wallets are positioned on your coin. Net agreement with your thesis raises
+     conviction; trading *against* heavy smart-money positioning lowers it. Confirmation only — never
+     the sole reason to enter.
 5. **Size with the risk brain, never by gut** —
    `node scripts/sizing.py size --equity <E> --price <P> --atr-pct <atr_pct> --win-rate <w>
    --payoff <b> --goodwill <g> --confidence <c>` (pull `--win-rate`/`--payoff` from

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -467,6 +467,29 @@ def global_predictors(h: Path) -> list[dict]:
     return sorted(board, key=lambda e: (-e["acc"], -e["correct"]))
 
 
+def intel_html(h: Path) -> str:
+    """Market intelligence panel — the regime + key features the agent now trades on."""
+    intel = load_json(h / "intel.json", {}).get("intel", {})
+    if not intel:
+        return '<p class="muted">No market scan yet — the intel engine runs each heartbeat.</p>'
+    color = {"trend_up": "var(--emerald)", "trend_down": "var(--red)",
+             "range": "var(--silver)", "chop": "var(--muted)"}
+    rows = []
+    for coin, f in intel.items():
+        if not f:
+            continue
+        reg = f.get("regime", "?")
+        rows.append(
+            f'<tr><td><b>{html.escape(coin)}</b></td>'
+            f'<td style="color:{color.get(reg, "var(--silver)")}">{reg}</td>'
+            f'<td>{f.get("rsi", "?")}</td><td>{f.get("atr_pct", "?")}%</td>'
+            f'<td>{f.get("funding_z", "?")}</td><td>{"✓" if f.get("tradeable") else "—"}</td></tr>')
+    return (f'<table class="lb"><tr><th>coin</th><th>regime</th><th>rsi</th><th>atr</th>'
+            f'<th>fund-z</th><th>trade?</th></tr>{"".join(rows)}</table>'
+            f'<p class="muted" style="margin-top:6px">Chop = sit out · trend = ride ema_stack · '
+            f'range = fade extremes. Sized by ATR + Kelly, only on regime-proven edge.</p>')
+
+
 def predictions_html(h: Path) -> str:
     """The free 'Call it' game — the open round + the GLOBAL predictors ladder."""
     rounds = load_json(h / "predictions" / "rounds.json", {})
@@ -533,6 +556,7 @@ def render_html(state: dict[str, Any], identity: str, journal: list, messages: l
         roster=roster_html(home()),
         leaderboard=leaderboard_html(home()),
         achievements=achievements_html(state),
+        intel=intel_html(home()),
         predictions=predictions_html(home()),
         topup=topup_html(home()),
         recodes=state.get("recodes", 0),
@@ -684,6 +708,7 @@ ul{{list-style:none;margin:0;padding:0}}.family li,.events li{{padding:7px 0;bor
     <div class="card decent"><h2>🏆 Leaderboard</h2>{leaderboard}</div>
   </div>
   <div class="card" style="margin-top:18px"><h2>🏅 Achievements</h2>{achievements}</div>
+  <div class="card decent" style="margin-top:18px"><h2>🧠 Market intelligence · regime + risk brain</h2>{intel}</div>
   <div class="card decent" style="margin-top:18px"><h2>🎯 Call it · predictions (free · onchain-anchored)</h2>{predictions}</div>
   <div class="card decent" style="margin-top:18px"><h2>💰 Top up your bot</h2><div class="topup">{topup}</div></div>
   <div class="grid2" style="margin-top:18px">

--- a/scripts/erc8004_register.js
+++ b/scripts/erc8004_register.js
@@ -100,6 +100,14 @@ function predictionsRoot() {
   } catch { return null; }
 }
 
+function tradingEdges() {
+  // This creature's proven technique x regime edges, published onchain so the
+  // family pools them into a collective trading-intelligence graph (memory.py swarm).
+  try {
+    return JSON.parse(fs.readFileSync(path.join(GCLAW_HOME, 'edges.json'), 'utf8')).slice(0, 12);
+  } catch { return []; }
+}
+
 function predictorTallies() {
   // This creature attests the record of predictors who called on ITS trades
   // (resolved against HyperLiquid's fills). Published onchain so the decentralized
@@ -171,7 +179,7 @@ function agentCard(state, managed, child) {
       goodwill: child ? 0 : state.goodwill ?? 0,
       controlWallet: JSON.parse(fs.readFileSync(WALLET_PATH, 'utf8')).control.address,
       managedHlWallet: managed,
-      ...(child ? {} : { stats: statsForCard(state), peers: knownPeers(), published: publishedTechniques(), predictions: predictionsRoot(), predictors: predictorTallies() }),
+      ...(child ? {} : { stats: statsForCard(state), peers: knownPeers(), published: publishedTechniques(), predictions: predictionsRoot(), predictors: predictorTallies(), edges: tradingEdges() }),
       ...lineage,
     },
   };

--- a/scripts/memory.py
+++ b/scripts/memory.py
@@ -44,6 +44,22 @@ def load() -> list[dict]:
     return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
 
 
+def _read_json(path: Path, default):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return default
+
+
+def _write_edges() -> None:
+    """Cache the proven-edge table to edges.json for the onchain card + dashboard."""
+    cells = summary(None)["table"]
+    edges = [{"t": c["technique"], "r": c["regime"], "e": c["expectancy_r"],
+              "n": c["trades"], "real": c["edge_real"]}
+             for c in cells if c["trades"] >= 3][:12]
+    (home() / "edges.json").write_text(json.dumps(edges), encoding="utf-8")
+
+
 def record(args: argparse.Namespace) -> dict:
     """Append one closed-trade outcome. R-multiple normalises pnl by risk taken."""
     risk = abs(args.risk) if args.risk else 0.0
@@ -61,7 +77,35 @@ def record(args: argparse.Namespace) -> dict:
     home().mkdir(parents=True, exist_ok=True)
     with store().open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(row) + "\n")
+    _write_edges()
     return {"ok": True, "recorded": row, "total": len(load())}
+
+
+def swarm(_args: argparse.Namespace) -> dict:
+    """The collective graph: pool technique x regime expectancy across the whole
+    family — self memory + every peer's onchain-published edges — into one table.
+    Trade-weighted, so a result proven across many creatures outranks a lucky one."""
+    cells: dict[tuple[str, str], dict] = {}
+
+    def add(tech: str, regime: str, exp: float, trades: int) -> None:
+        c = cells.setdefault((tech, regime), {"wexp": 0.0, "trades": 0, "creatures": 0})
+        c["wexp"] += exp * trades
+        c["trades"] += trades
+        c["creatures"] += 1 if trades else 0
+
+    for cell in summary(None)["table"]:
+        add(cell["technique"], cell["regime"], cell["expectancy_r"], cell["trades"])
+    for peer in _read_json(home() / "peers_roster.json", {}).get("roster", []):
+        if peer.get("self"):
+            continue
+        for e in peer.get("edges", []):
+            add(e.get("t", "?"), e.get("r", "?"), float(e.get("e", 0)), int(e.get("n", 0)))
+    table = [{"technique": t, "regime": r,
+              "expectancy_r": round(c["wexp"] / c["trades"], 3) if c["trades"] else 0,
+              "trades": c["trades"], "creatures": c["creatures"]}
+             for (t, r), c in cells.items()]
+    table.sort(key=lambda e: e["expectancy_r"], reverse=True)
+    return {"ok": True, "collective": table}
 
 
 def _bootstrap_ci(rs: list[float], iters: int = 2000) -> tuple[float, float]:
@@ -151,8 +195,10 @@ def main() -> int:
     q = sub.add_parser("query")
     q.add_argument("--regime", required=True)
     sub.add_parser("summary")
+    sub.add_parser("swarm")
     args = p.parse_args()
-    fn = {"record": record, "expectancy": expectancy, "query": query, "summary": summary}[args.command]
+    fn = {"record": record, "expectancy": expectancy, "query": query,
+          "summary": summary, "swarm": swarm}[args.command]
     print(json.dumps(fn(args), indent=2))
     return 0
 

--- a/scripts/peers.js
+++ b/scripts/peers.js
@@ -59,6 +59,7 @@ async function readAgent(id) {
   return { id: Number(id), name: meta.name || null, owner, image: meta.image || null,
     stats: meta['x-gclaw']?.stats || null,  // live standings beacon, read straight from chain
     predictors: meta['x-gclaw']?.predictors || [],  // who called this creature's trades right — for the global ladder
+    edges: meta['x-gclaw']?.edges || [],  // proven technique x regime edges — for the collective swarm graph
     published: meta['x-gclaw']?.published || [],  // proven techniques advertised for discovery
     isGclaw: typeof meta.description === 'string' && meta.description.includes(SIGNATURE) };
 }


### PR DESCRIPTION
Second pass on the trading intelligence stack.

- **memory.py `swarm`** — pools every creature's `technique × regime → edge` (self + peers' onchain-published edges) into one trade-weighted collective table. A result proven across the family outranks a lucky local sample, and a creature can act on an edge it never traded itself.
- **erc8004 / peers.js** — publishes `x-gclaw.edges` onchain and reads peers' edges. Network-effect data asset on the existing gossip rails.
- **dashboard** — a 🧠 Market intelligence panel (per-coin regime + RSI/ATR/funding-z/tradeable).
- **trading DNA** — consult the swarm graph and smart-money (top-PnL wallet positioning, GDEX MCP) as entry confirmation.

Verified: swarm merges self+peer edges trade-weighted; card publishes edges.json; panel renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)