### PR TITLE
Fix prediction resolve crash + trade-memory attribution

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -83,8 +83,9 @@ You have a perception + risk stack. **Use it; do not trade on a raw price glance
    --payoff <b> --goodwill <g> --confidence <c>` (pull `--win-rate`/`--payoff` from
    `memory.py expectancy --technique <t> --regime <r>`). Open with exactly the returned `notional`,
    `size`, and ATR-based stop. This caps any single trade's risk to a fixed fraction of equity —
-   no trade can dominate the P&L again. Write the intended risk to `~/.gclaw/open_risk.json`
-   (`{"<coin>": <risk_usd>}`) so the close records a true R-multiple.
+   no trade can dominate the P&L again. At entry, write the risk **and a short thesis label**
+   to `~/.gclaw/open_risk.json` (`{"<coin>": {"risk": <usd>, "technique": "<short-label>"}}`) so
+   the close records a true R-multiple under a named, learnable strategy — not "discretionary".
 6. For events: scan `hl_outcomes` for near-dated markets with real volume and a price that diverges
    from your estimate.
 7. On close, settle (auto). Each close is auto-recorded to the trade-memory with its regime, so your

--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -155,19 +155,24 @@ async function main() {
     // record the outcome to the trade-memory (technique x regime -> R) so the agent
     // learns which techniques actually work in which conditions.
     for (const f of closers) {
-      let technique = 'unknown';
+      let technique = '';
       try {
         const out = execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'forge.py'),
           'royalty', '--coin', String(f.coin), '--pnl', String(f.closedPnl), '--auto'],
         { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'pipe', 'ignore'] });
-        technique = JSON.parse(out.toString()).technique || 'unknown';
+        technique = JSON.parse(out.toString()).technique || '';
       } catch { /* attribution is best-effort */ }
       try {
+        // open_risk.json entry may be a bare risk number or {risk, technique} the
+        // agent labelled at entry. Fall back to "discretionary" (a learnable bucket).
+        const orec = openRisk[f.coin];
+        const labelled = orec && typeof orec === 'object' ? orec : { risk: orec };
         const notional = Math.abs(Number(f.sz || 0)) * Number(f.px || 0);
-        const risk = openRisk[f.coin] || notional * 0.015 || 0.25; // sized risk, else 1.5%-stop estimate
+        const risk = labelled.risk || notional * 0.015 || 0.25; // sized risk, else 1.5%-stop estimate
+        const tech = technique || labelled.technique || 'discretionary';
         const side = String(f.dir || '').includes('Short') ? 'short' : 'long';
         execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'memory.py'),
-          'record', '--coin', String(f.coin), '--technique', String(technique),
+          'record', '--coin', String(f.coin), '--technique', String(tech),
           '--regime', regimes[f.coin] || 'unknown', '--side', side,
           '--pnl', String(f.closedPnl), '--risk', String(risk)],
         { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'ignore', 'ignore'] });

--- a/scripts/predict.js
+++ b/scripts/predict.js
@@ -123,7 +123,7 @@ function cmdCall(args) {
   return { ok: true, called: entry };
 }
 
-async function cmdResolve() {
+async function cmdResolve(args) {
   const rounds = readJson(roundsPath(), {});
   const open = Object.values(rounds).filter((r) => r.status === 'open');
   if (!open.length) return { ok: true, resolved: [] };


### PR DESCRIPTION
Two gaps surfaced by a live heartbeat run.

- **predict.js** — `cmdResolve` used `args` without declaring it, so `resolve --announce` threw `args is not defined` and rounds never scored after a trade closed. Now captured. (Verified: the open SOL round resolved SL −$0.86, @AssuneGOD's TP scored 0/1.)
- **autosettle.js** — model-opened trades attributed to `unknown`; now default to `discretionary` (learnable) and honour a `{risk, technique}` label from `open_risk.json`.
- **DNA** — agent labels its thesis at entry so closes attribute to a named strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)