### PR TITLE
Deterministic risk guardrail (enforce the risk cap the model ignores)

### DIFF
--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -80,6 +80,12 @@ else
     node "$SKILL_DIR/scripts/notify.js" send critical "heartbeat exited non-zero" >>"$LOG" 2>&1 || true
 fi
 
+# Risk guardrail: the model bypasses sizing.py, so enforce the per-trade and
+# portfolio risk caps deterministically — trim any position over the cap and
+# flatten naked ones. Runs AFTER the cycle to catch what the model just opened.
+[[ -f "$SKILL_DIR/scripts/riskguard.js" ]] &&
+  echo "$(ts) riskguard: $(node "$SKILL_DIR/scripts/riskguard.js" run 2>&1)" >>"$LOG" || true
+
 # "Call it" prediction game: score any round whose trade just closed, then open a
 # round for any new trade — BEFORE the dashboard render anchors the root onchain.
 [[ -f "$SKILL_DIR/scripts/predict.js" ]] && {

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -276,12 +276,15 @@ async function cmdClose(wallet, args) {
   const { skill, creds } = await signedSkill(wallet);
   const szi = await positionSize(skill, wallet.managed, coin);
   if (!szi) return { ok: true, action: 'close', coin, note: 'no open position' };
+  // Optional partial reduce: --size <amount> closes only that much (reduceOnly),
+  // clamped to the open size. Omitted → flatten the whole position.
+  const want = args.size ? Math.min(Math.abs(Number(args.size)), Math.abs(szi)) : Math.abs(szi);
   const px = await markPriceFor(skill, coin);
   const res = await skill.hlCreateOrder({
     coin,
     isLong: szi < 0, // opposite side to flatten
     price: String(px),
-    size: String(Math.abs(szi)),
+    size: String(want),
     reduceOnly: true,
     isMarket: true,
     tpPrice: '0',
@@ -289,7 +292,7 @@ async function cmdClose(wallet, args) {
     ...creds,
   });
   if (res && res.isSuccess === false) die(`close rejected: ${JSON.stringify(res)}`);
-  return { ok: true, action: 'close', coin, closedSize: Math.abs(szi), mark: px };
+  return { ok: true, action: 'close', coin, closedSize: want, partial: want < Math.abs(szi), mark: px };
 }
 
 async function cmdCancel(wallet, args) {

--- a/scripts/riskguard.js
+++ b/scripts/riskguard.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * riskguard.js — the deterministic risk guardrail.
+ *
+ * The risk brain (sizing.py) is advisory and the model bypasses it, so positions
+ * get opened far over their risk budget (the −$4 / −$6 blow-ups). This enforces the
+ * cap AFTER the fact, every heartbeat, with hard-coded limits the model cannot argue
+ * with: it reads each position's real stop, computes the $ at risk, and physically
+ * TRIMS anything over the per-trade or portfolio cap. Naked positions (no stop) are
+ * flattened. It only ever REDUCES exposure — never opens, never adds — so it is safe
+ * to run unattended under the anti-drain model.
+ *
+ *   node riskguard.js run        # enforce now (trims over-cap positions)
+ *   node riskguard.js check      # dry-run: report what it WOULD do, trade nothing
+ *
+ * Env: GCLAW_HOME, plus whatever hl_perp.js needs (wallet/SDK).
+ */
+'use strict';
+
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const SKILL_DIR = __dirname;
+const RISK_CAP_PCT = 1.5;       // max % of equity at risk on a single trade
+const PORTFOLIO_CAP_PCT = 4.0;  // max total % of equity at risk across all trades
+const TOLERANCE = 1.15;         // don't churn a position for being <15% over
+const MIN_NOTIONAL = 11;        // HL min — below this we flatten rather than dust-trim
+
+function hl(args) {
+  const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), ...args],
+    { encoding: 'utf8', timeout: 90000 });
+  return JSON.parse(out.trim().split('\n').pop());
+}
+
+// The protective stop is the reduce-only order on the LOSS side: above entry for a
+// short, below entry for a long. Nearest such order is what triggers first.
+function stopFor(coin, entry, isShort, orders) {
+  const lossSide = orders.filter((o) => o.coin === coin && o.reduceOnly
+    && (isShort ? Number(o.px) > entry : Number(o.px) < entry));
+  if (!lossSide.length) return null;
+  const pxs = lossSide.map((o) => Number(o.px));
+  return isShort ? Math.min(...pxs) : Math.max(...pxs);
+}
+
+function assess(st) {
+  const eq = Number(st.equity) || 0;
+  const orders = st.openOrders || [];
+  return (st.positions || []).map((p) => {
+    const size = Math.abs(Number(p.size));
+    const entry = Number(p.entryPx);
+    const isShort = Number(p.size) < 0;
+    const stop = stopFor(p.coin, entry, isShort, orders);
+    const notional = size * entry;
+    const risk = stop == null ? notional : Math.abs(entry - stop) * size; // naked = whole notional
+    return { coin: p.coin, size, entry, isShort, stop, notional, risk,
+      riskPct: eq ? (risk / eq) * 100 : 0, naked: stop == null };
+  });
+}
+
+function reduce(coin, size, dry) {
+  if (dry) return { coin, wouldReduce: Number(size.toFixed(6)) };
+  return hl(['close', '--coin', coin, '--size', String(size)]);
+}
+
+function flatten(coin, dry) {
+  if (dry) return { coin, wouldFlatten: true };
+  return hl(['close', '--coin', coin]);
+}
+
+function enforce(dry) {
+  const st = hl(['status']);
+  const eq = Number(st.equity) || 0;
+  if (!eq) return { ok: false, error: 'no equity read' };
+  const cap = eq * (RISK_CAP_PCT / 100);
+  const portCap = eq * (PORTFOLIO_CAP_PCT / 100);
+  const actions = [];
+  let positions = assess(st);
+
+  // 1. Naked positions (no protective stop) — flatten immediately.
+  for (const p of positions.filter((x) => x.naked)) {
+    actions.push({ coin: p.coin, reason: 'NAKED — no stop', action: flatten(p.coin, dry), riskPct: Math.round(p.riskPct * 10) / 10 });
+  }
+  positions = positions.filter((x) => !x.naked);
+
+  // 2. Per-trade cap — trim each over-cap position down to the cap.
+  for (const p of positions) {
+    if (p.risk <= cap * TOLERANCE) continue;
+    const targetSize = p.size * (cap / p.risk);
+    const reduceBy = p.size - targetSize;
+    const flat = targetSize * p.entry < MIN_NOTIONAL; // would leave dust → flatten
+    actions.push({ coin: p.coin, reason: `per-trade ${p.riskPct.toFixed(1)}% > ${RISK_CAP_PCT}% cap`,
+      from_risk: Math.round(p.risk * 100) / 100, to_risk: Math.round(cap * 100) / 100,
+      action: flat ? flatten(p.coin, dry) : reduce(p.coin, reduceBy, dry) });
+    p.risk = flat ? 0 : cap; // updated for the portfolio pass
+  }
+
+  // 3. Portfolio cap — if the book still risks too much, trim the largest first.
+  let total = positions.reduce((s, p) => s + p.risk, 0);
+  const order = [...positions].sort((a, b) => b.risk - a.risk);
+  for (const p of order) {
+    if (total <= portCap * TOLERANCE) break;
+    if (!p.risk) continue;
+    const cut = Math.min(p.risk, total - portCap);
+    const reduceBy = p.size * (cut / p.risk);
+    actions.push({ coin: p.coin, reason: `portfolio ${(total / eq * 100).toFixed(1)}% > ${PORTFOLIO_CAP_PCT}% cap`,
+      action: reduce(p.coin, reduceBy, dry) });
+    total -= cut;
+  }
+
+  return { ok: true, dry: !!dry, equity: Math.round(eq * 100) / 100,
+    per_trade_cap_usd: Math.round(cap * 100) / 100, portfolio_cap_usd: Math.round(portCap * 100) / 100,
+    book: positions.map((p) => ({ coin: p.coin, riskPct: Math.round(p.riskPct * 10) / 10 })),
+    actions };
+}
+
+function main() {
+  const cmd = process.argv[2] || 'check';
+  const out = enforce(cmd !== 'run');
+  process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+}
+
+main();


### PR DESCRIPTION
Forensics on the losing book: `sizing.py` (the risk brain) has **0** invocations — the model sizes by gut, so the ETH short opened at **3.1% of equity at risk, 2.1× the cap** (the original −$4 failure mode, back again).

`riskguard.js` makes the cap a **hard, deterministic guardrail**: every heartbeat it reads each position's real stop, computes the $ at risk, and physically **trims** anything over the **1.5%/trade** or **4%/portfolio** cap — and **flattens naked** (stopless) positions. Reduce-only, so safe unattended. `hl_perp.js close` gains `--size` for partial reduction. Wired post-cycle to catch oversize the same heartbeat it's opened.

Dry-run verified against the live book: BTC 0.5% (untouched), ETH 3.1% → trim to the $3.07 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)