### PR TITLE
Hybrid model selection (Opus only when it counts)

### DIFF
--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -61,6 +61,14 @@ cd "$HOME"
   node "$SKILL_DIR/scripts/intel.js" scan >"$GCLAW_HOME/intel.json" 2>>"$LOG" &&
   echo "$(ts) intel: $(uv run --no-project python3 -c 'import json;d=json.load(open("'"$GCLAW_HOME"'/intel.json"));print({k:(v["regime"] if v else None) for k,v in d.get("intel",{}).items()})' 2>/dev/null)" >>"$LOG" || true
 
+# Hybrid model: escalate to Opus only when the cycle needs judgment (a position to
+# manage or a live setup), else Sonnet for the routine quiet cycle. Runs after the
+# intel scan so the setup signal is fresh. An explicit GCLAW_MODEL overrides.
+if [[ -f "$SKILL_DIR/scripts/model_select.js" ]]; then
+  MODEL="$(node "$SKILL_DIR/scripts/model_select.js" 2>>"$LOG" || echo "$MODEL")"
+fi
+echo "$(ts) model: $MODEL" >>"$LOG"
+
 # Anti-drain: the heartbeat runs unattended with bypassPermissions, and reads
 # untrusted text (peer cards, family bus, market data, gene-pool metadata) that
 # could carry a prompt-injection payload. Deny every tool that can move funds to

--- a/scripts/model_select.js
+++ b/scripts/model_select.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * model_select.js — pick the heartbeat model by how much judgment the cycle needs.
+ *
+ * Opus reasoning is ~5x the cost of Sonnet, and most heartbeats are "flat, nothing
+ * to do." So escalate to Opus ONLY when the decision actually matters:
+ *   - a position is open (exit / management calls are where money is won or lost), or
+ *   - a live, non-chop setup is present (a real entry to weigh).
+ * Otherwise Sonnet handles the routine cycle cheaply. Prints just the model name so
+ * the heartbeat can use it inline; an explicit GCLAW_MODEL always wins (manual override).
+ *
+ *   node model_select.js            # prints "opus" or "sonnet" (+ reason on stderr)
+ *
+ * Reads $GCLAW_HOME/intel.json (written earlier in the heartbeat) and live positions.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
+const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+
+function positionCount() {
+  try {
+    const out = execFileSync('node', [path.join(__dirname, 'hl_perp.js'), 'status'],
+      { encoding: 'utf8', timeout: 60000 });
+    return (JSON.parse(out.trim().split('\n').pop()).positions || []).length;
+  } catch { return 0; }
+}
+
+// A coin worth Opus: tradeable (not chop) AND showing a real, actionable edge —
+// an RSI extreme, a stretched mean-reversion band, a crowded funding book, or a
+// clean trend with momentum behind it.
+function liveSetup(intel) {
+  return Object.values(intel || {}).some((f) => f && f.tradeable && (
+    f.rsi <= 30 || f.rsi >= 70
+    || Math.abs(f.bb_z) >= 1.5
+    || Math.abs(f.funding_z) >= 1.5
+    || (Math.abs(f.ema_stack) === 2 && Math.abs(f.ema_slope_pct) >= 1)
+  ));
+}
+
+function main() {
+  if (process.env.GCLAW_MODEL) { process.stdout.write(process.env.GCLAW_MODEL); return; }
+  const intel = readJson(path.join(GCLAW_HOME, 'intel.json'), {}).intel || {};
+  const positions = positionCount();
+  let model = 'sonnet';
+  let reason = 'flat + no live setup — routine cycle';
+  if (positions > 0) { model = 'opus'; reason = `${positions} open position(s) to manage`; }
+  else if (liveSetup(intel)) { model = 'opus'; reason = 'live non-chop setup to weigh'; }
+  process.stderr.write(`model_select: ${model} (${reason})\n`);
+  process.stdout.write(model);
+}
+
+main();


### PR DESCRIPTION
Opus is ~5× Sonnet's cost and most heartbeats are flat/quiet. `model_select.js` escalates to **Opus only when the decision matters** — a position is open to manage, or a live non-chop setup is present (RSI extreme / stretched Bollinger / crowded funding / clean trend). Otherwise **Sonnet** runs the routine cycle. Reads the fresh intel scan + live positions; `GCLAW_MODEL` overrides.

Verified: 2 open positions → opus; flat+chop → sonnet; flat+RSI28 setup → opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)