### PR TITLE
Adaptive heartbeat cadence (hourly active, ~4h idle)

### DIFF
--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -61,31 +61,35 @@ cd "$HOME"
   node "$SKILL_DIR/scripts/intel.js" scan >"$GCLAW_HOME/intel.json" 2>>"$LOG" &&
   echo "$(ts) intel: $(uv run --no-project python3 -c 'import json;d=json.load(open("'"$GCLAW_HOME"'/intel.json"));print({k:(v["regime"] if v else None) for k,v in d.get("intel",{}).items()})' 2>/dev/null)" >>"$LOG" || true
 
-# Hybrid model: escalate to Opus only when the cycle needs judgment (a position to
-# manage or a live setup), else Sonnet for the routine quiet cycle. Runs after the
-# intel scan so the setup signal is fresh. An explicit GCLAW_MODEL overrides.
-if [[ -f "$SKILL_DIR/scripts/model_select.js" ]]; then
-  MODEL="$(node "$SKILL_DIR/scripts/model_select.js" 2>>"$LOG" || echo "$MODEL")"
-fi
-echo "$(ts) model: $MODEL" >>"$LOG"
-
-# Anti-drain: the heartbeat runs unattended with bypassPermissions, and reads
-# untrusted text (peer cards, family bus, market data, gene-pool metadata) that
-# could carry a prompt-injection payload. Deny every tool that can move funds to
-# an arbitrary destination — legit funding is done by deterministic scripts
-# (autofund/gmac_buy) with HARD-CODED destinations, never by the model.
-# --disallowedTools is variadic (space-separated) and would consume a positional
-# prompt — so the deny-list goes LAST (unquoted for word-split) and the prompt is
-# piped via stdin.
-# shellcheck disable=SC2086  # intentional word-split: --disallowedTools is variadic
-DENY="mcp__gdex__transfer_native mcp__gdex__transfer_token mcp__gdex__execute_bridge mcp__gdex__perp_withdraw mcp__gdex__hl_swap_collateral mcp__gdex__managed_sell mcp__gdex__sell_token"
-if printf '%s' "$PROMPT" | timeout 600 claude --print --permission-mode bypassPermissions \
-    --model "$MODEL" --disallowedTools $DENY >>"$LOG" 2>&1; then
-  echo "===== $(ts) heartbeat ok =====" >>"$LOG"
+# Adaptive cadence + hybrid model. "active" = a position to manage or a live setup.
+# When active: run every heartbeat on Opus. When idle (flat + quiet): run the LLM
+# only every GCLAW_FLAT_INTERVAL_H hours (default 4) on Sonnet — the deterministic
+# steps still run hourly, but we don't burn the LLM (and your plan allowance) on
+# "nothing to do" cycles. An explicit GCLAW_MODEL overrides the model, not the cadence.
+ACTIVE="active"; FLAT_INTERVAL_H="${GCLAW_FLAT_INTERVAL_H:-4}"
+[[ -f "$SKILL_DIR/scripts/model_select.js" ]] && ACTIVE="$(node "$SKILL_DIR/scripts/model_select.js" active 2>>"$LOG" || echo active)"
+LAST_CYCLE="$(cat "$GCLAW_HOME/last_cycle" 2>/dev/null || echo 0)"; NOW="$(date +%s)"
+if [[ "$ACTIVE" == "idle" && $((NOW - LAST_CYCLE)) -lt $((FLAT_INTERVAL_H * 3600)) ]]; then
+  echo "$(ts) cycle skipped: idle (flat, no setup) — last LLM cycle $(((NOW - LAST_CYCLE) / 60))m ago < ${FLAT_INTERVAL_H}h" >>"$LOG"
 else
-  echo "===== $(ts) heartbeat exited non-zero ($?) =====" >>"$LOG"
-  [[ -f "$SKILL_DIR/scripts/notify.js" ]] &&
-    node "$SKILL_DIR/scripts/notify.js" send critical "heartbeat exited non-zero" >>"$LOG" 2>&1 || true
+  [[ -f "$SKILL_DIR/scripts/model_select.js" ]] &&
+    MODEL="$(node "$SKILL_DIR/scripts/model_select.js" model 2>>"$LOG" || echo "$MODEL")"
+  echo "$(ts) model: $MODEL ($ACTIVE)" >>"$LOG"
+  # Anti-drain: the heartbeat runs unattended with bypassPermissions, and reads
+  # untrusted text (peer cards, family bus, market data, gene-pool metadata) that
+  # could carry a prompt-injection payload. Deny every tool that can move funds to
+  # an arbitrary destination — legit funding is done by deterministic scripts
+  # (autofund/gmac_buy) with HARD-CODED destinations, never by the model.
+  # shellcheck disable=SC2086  # intentional word-split: --disallowedTools is variadic
+  DENY="mcp__gdex__transfer_native mcp__gdex__transfer_token mcp__gdex__execute_bridge mcp__gdex__perp_withdraw mcp__gdex__hl_swap_collateral mcp__gdex__managed_sell mcp__gdex__sell_token"
+  if printf '%s' "$PROMPT" | timeout 600 claude --print --permission-mode bypassPermissions \
+      --model "$MODEL" --disallowedTools $DENY >>"$LOG" 2>&1; then
+    echo "===== $(ts) heartbeat ok =====" >>"$LOG"; date +%s >"$GCLAW_HOME/last_cycle"
+  else
+    echo "===== $(ts) heartbeat exited non-zero ($?) =====" >>"$LOG"
+    [[ -f "$SKILL_DIR/scripts/notify.js" ]] &&
+      node "$SKILL_DIR/scripts/notify.js" send critical "heartbeat exited non-zero" >>"$LOG" 2>&1 || true
+  fi
 fi
 
 # Risk guardrail: the model bypasses sizing.py, so enforce the per-trade and

--- a/scripts/model_select.js
+++ b/scripts/model_select.js
@@ -43,15 +43,23 @@ function liveSetup(intel) {
   ));
 }
 
-function main() {
-  if (process.env.GCLAW_MODEL) { process.stdout.write(process.env.GCLAW_MODEL); return; }
+// "active" = the cycle needs real judgment: a position to manage or a live setup.
+// Drives BOTH the model (Opus when active) and the cadence (run hourly when active,
+// stretch when idle). Ignores GCLAW_MODEL so a forced model doesn't disable cadence.
+function activity() {
   const intel = readJson(path.join(GCLAW_HOME, 'intel.json'), {}).intel || {};
   const positions = positionCount();
-  let model = 'sonnet';
-  let reason = 'flat + no live setup — routine cycle';
-  if (positions > 0) { model = 'opus'; reason = `${positions} open position(s) to manage`; }
-  else if (liveSetup(intel)) { model = 'opus'; reason = 'live non-chop setup to weigh'; }
-  process.stderr.write(`model_select: ${model} (${reason})\n`);
+  if (positions > 0) return { active: true, reason: `${positions} open position(s) to manage` };
+  if (liveSetup(intel)) return { active: true, reason: 'live non-chop setup to weigh' };
+  return { active: false, reason: 'flat + no live setup — routine cycle' };
+}
+
+function main() {
+  const cmd = process.argv[2] || 'model';
+  const a = activity();
+  if (cmd === 'active') { process.stdout.write(a.active ? 'active' : 'idle'); return; }
+  const model = process.env.GCLAW_MODEL || (a.active ? 'opus' : 'sonnet');
+  process.stderr.write(`model_select: ${model} (${a.reason})\n`);
   process.stdout.write(model);
 }
 


### PR DESCRIPTION
The expensive LLM cycle now runs every heartbeat only when **active** (a position to manage or a live setup); when **idle** (flat + quiet) it runs at most every `GCLAW_FLAT_INTERVAL_H` hours (default 4). Deterministic steps (autofund/autotrail/autosettle/intel/riskguard/dashboard) still run hourly. Conserves the plan allowance for the cycles that matter — and for the operator's own Claude usage. `model_select.js` gains `active`/`model` subcommands; `GCLAW_MODEL` overrides the model, not the cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)