### PR TITLE
Security: close forge sandbox RCE + widen fund-drain deny-list

### DIFF
--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -73,6 +73,10 @@ BANNED_NAMES = {
 }
 # Attribute access that can pivot to builtins/globals even without a dunder name.
 BANNED_ATTRS = {"format", "format_map", "mro", "__class__", "__globals__", "__subclasses__"}
+# Frame/generator/code/coroutine/traceback introspection attributes have no leading
+# dunder, so they slip past the "__"-prefix check and let a signal walk the call
+# stack (gi_frame.f_back.f_builtins) to the real __import__ → RCE. Block by prefix.
+BANNED_ATTR_PREFIXES = ("__", "gi_", "f_", "co_", "cr_", "tb_", "func_", "ag_")
 SIGNAL_TIMEOUT_S = 2
 
 
@@ -321,7 +325,8 @@ def validate_signal_src(src: str) -> list[str]:
                 violations.append(f"import not allowed: from {node.module}")
         elif isinstance(node, ast.Name) and (node.id in BANNED_NAMES or node.id.startswith("__")):
             violations.append(f"banned name: {node.id}")
-        elif isinstance(node, ast.Attribute) and (node.attr.startswith("__") or node.attr in BANNED_ATTRS):
+        elif isinstance(node, ast.Attribute) and (
+                node.attr in BANNED_ATTRS or node.attr.startswith(BANNED_ATTR_PREFIXES)):
             violations.append(f"banned attribute access: {node.attr}")
     if not any(isinstance(n, ast.FunctionDef) and n.name == "signal"
                for n in ast.walk(tree)):

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -81,7 +81,11 @@ else
   # an arbitrary destination — legit funding is done by deterministic scripts
   # (autofund/gmac_buy) with HARD-CODED destinations, never by the model.
   # shellcheck disable=SC2086  # intentional word-split: --disallowedTools is variadic
-  DENY="mcp__gdex__transfer_native mcp__gdex__transfer_token mcp__gdex__execute_bridge mcp__gdex__perp_withdraw mcp__gdex__hl_swap_collateral mcp__gdex__managed_sell mcp__gdex__sell_token"
+  # Deny every tool that moves funds to an arbitrary destination, buys an arbitrary
+  # token, or hands the wallet to a third party. The legit HL-perp trading tools
+  # (open_perp_position/place_perp_order/limit_*) stay allowed — riskguard caps their
+  # risk deterministically. GMAC + funding moves are deterministic scripts, not the model.
+  DENY="mcp__gdex__transfer_native mcp__gdex__transfer_token mcp__gdex__execute_bridge mcp__gdex__perp_withdraw mcp__gdex__hl_swap_collateral mcp__gdex__managed_sell mcp__gdex__sell_token mcp__gdex__buy_token mcp__gdex__managed_purchase mcp__gdex__execute_spot mcp__gdex__execute_cross_perp mcp__gdex__execute_isolated_perp mcp__gdex__create_copy_trade mcp__gdex__create_hl_copy_trade"
   if printf '%s' "$PROMPT" | timeout 600 claude --print --permission-mode bypassPermissions \
       --model "$MODEL" --disallowedTools $DENY >>"$LOG" 2>&1; then
     echo "===== $(ts) heartbeat ok =====" >>"$LOG"; date +%s >"$GCLAW_HOME/last_cycle"


### PR DESCRIPTION
Audit found two drain vectors, both fixed:

- **forge.py sandbox RCE (critical):** the validator blocked `__`-prefixed attributes but not frame introspection (`gi_frame`/`f_back`/`f_builtins`/`co_name`). A peer-authored technique could walk the call stack to the real `__import__` and run code as the wallet owner — confirmed with a working exploit. Now blocked by attribute prefix; verified the exploit is rejected and legit signals still pass.
- **heartbeat deny-list (high):** added `buy_token`, `managed_purchase`, `execute_spot/cross_perp/isolated_perp`, `create_copy_trade/create_hl_copy_trade`. Legit HL-perp trading tools stay allowed (riskguard bounds their risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)