### PR TITLE
Audit hardening: atomicity, idempotency, state hygiene, breaker enforcement

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -97,14 +97,13 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
    - Close perp: `mcp__gdex__close_perp_position {apiKey, walletAddress, sessionPrivateKey, coin}`.
    - Outcome bet (defined-risk events): `node scripts/hl_outcomes.js list` then `order --outcome <id> --coin <side> --buy --price <p> --size <n>`
      (fund via `mcp__gdex__hl_swap_collateral` first). See `references/trading.md` §B. Prefer these in SURVIVE mode.
-7. **Settle.** On any realized close, record PnL in GMAC terms (1 GMAC ≈ 1 USD realized):
-   `uv run --no-project python3 scripts/metabolism.py settle --pnl <usd_pnl> --note "<what>"`.
-   If the close was a forge-originated trade, also attribute it: `forge.py royalty --coin <coin> --pnl
-   <usd_pnl>` — this credits the technique's author their royalty (and builds your own techniques' track record).
-   This auto-earmarks 10% into the GMAC buy-back treasury. Charge a discovery cost for heavy
-   intel cycles: `... metabolism.py charge --amount 0.5 --reason discovery`.
-   **GMAC buy-back:** if `gmac_treasury_usd` ≥ ~$5, follow `references/gmac.md` — bridge profit to
-   Ethereum and `node scripts/gmac_buy.js buy --usd <treasury>`, then `metabolism.py gmac --spend ...`.
+7. **Settle — automatic, do NOT do by hand.** Realized closes are booked deterministically every
+   heartbeat by `autosettle.js`: it reads HyperLiquid's fills, credits PnL to GMAC, earmarks 10% to
+   the buy-back treasury, attributes the technique royalty, and records the trade to memory. Calling
+   `metabolism.py settle` or `forge.py royalty` yourself would **double-count** — don't. Only charge a
+   discovery cost for heavy intel cycles: `... metabolism.py charge --amount 0.5 --reason discovery`.
+   **GMAC buy-back:** if `gmac_treasury_usd` ≥ ~$5, run `node scripts/gmac_buy.js buy --usd <treasury>`
+   — it decrements the treasury itself on a confirmed buy (no manual `gmac --spend`).
 8. **Evolve.** `uv run --no-project python3 scripts/evolve.py capabilities`. If a threshold is newly
    crossed, follow `references/evolution.md`: replicate a mutated child **with a swarm role**
    (`evolve.py replicate --name <n> --role scout|analyst|executor|leader --mutation "<axis>"`),

--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -48,8 +48,14 @@ function loadCursor() {
   return JSON.parse(fs.readFileSync(CURSOR_PATH, 'utf8'));
 }
 
+function writeAtomic(p, data) {
+  const tmp = `${p}.tmp${process.pid}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, p); // atomic on the same filesystem — a reader never sees a half-write
+}
+
 function saveCursor(c) {
-  fs.writeFileSync(CURSOR_PATH, JSON.stringify(c, null, 2) + '\n');
+  writeAtomic(CURSOR_PATH, JSON.stringify(c, null, 2) + '\n');
 }
 
 function managedAddress() {
@@ -142,11 +148,15 @@ async function main() {
   // advance time cursors over all consumed fills + funding
   const maxTime = Math.max(cursor.lastTime, ...(fresh.length ? fresh.map((f) => f.time) : [cursor.lastTime]));
   const tidsAtMax = fills.filter((f) => f.time === maxTime).map((f) => f.tid);
-  let residual = net;
+  const willSettle = Math.abs(net) >= DUST;
+  let residual = willSettle ? 0 : net;
   let settled = false;
-  if (Math.abs(net) >= DUST) {
+  // Advance the cursor BEFORE settling so a crash between settle() and the cursor
+  // write can't re-read the same fills and double-book the PnL. Fail-conservative:
+  // a crash mid-settle drops this batch (under-counts) rather than double-counting.
+  saveCursor({ lastTime: maxTime, lastTids: tidsAtMax, residual, lastFundingTime: maxFundingTime });
+  if (willSettle) {
     settle(net, `auto-settle: ${fresh.length} fills, ${closes} closes, funding ${summary.fundingPnl}`);
-    residual = 0;
     settled = true;
     const closers = fresh.filter((x) => Number(x.closedPnl || 0) !== 0);
     const regimes = fetchRegimes([...new Set(closers.map((f) => f.coin))]);
@@ -179,7 +189,6 @@ async function main() {
       } catch { /* memory record is best-effort */ }
     }
   }
-  saveCursor({ lastTime: maxTime, lastTids: tidsAtMax, residual, lastFundingTime: maxFundingTime });
   summary.settled = settled;
   summary.carriedResidual = residual;
   process.stdout.write(JSON.stringify(summary) + '\n');

--- a/scripts/evolve.py
+++ b/scripts/evolve.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -54,8 +55,12 @@ def load_state() -> dict[str, Any]:
 
 
 def save_state(state: dict[str, Any]) -> None:
+    # Atomic write — metabolism.json holds GMAC/goodwill/treasury and is shared with
+    # metabolism.py; a crash mid-write must not corrupt it. temp + os.replace.
     path = gclaw_home() / "metabolism.json"
-    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp = path.with_suffix(f".json.tmp{os.getpid()}")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
 
 
 def append_journal(entry: dict[str, Any]) -> None:

--- a/scripts/gmac_buy.js
+++ b/scripts/gmac_buy.js
@@ -109,7 +109,21 @@ async function main() {
       dex: info.dex,
       ...creds,
     });
-    console.log(JSON.stringify({ ok: res?.isSuccess !== false, spendEth: ethAmount, ethPrice, result: res, ...plan }));
+    const ok = res?.isSuccess !== false;
+    // Decrement the treasury HERE on a confirmed buy — never rely on the model to
+    // record it later (a forgotten or duplicated manual step double-spends the ETH).
+    let recorded = false;
+    if (ok) {
+      const tx = res?.txHash || res?.hash || res?.transactionHash || '';
+      try {
+        require('node:child_process').execFileSync('uv', ['run', '--no-project', 'python3',
+          path.join(__dirname, 'metabolism.py'), 'gmac', '--spend', String(usd),
+          '--tokens', String(plan.expectedTokens), '--tx', String(tx)],
+        { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'ignore', 'inherit'] });
+        recorded = true;
+      } catch (e) { console.error('WARN: buy confirmed but treasury decrement failed —', e.message); }
+    }
+    console.log(JSON.stringify({ ok, recorded, spendEth: ethAmount, ethPrice, result: res, ...plan }));
     return;
   }
   throw new Error('usage: gmac_buy.js <plan|buy> [--usd N]');

--- a/scripts/memory.py
+++ b/scripts/memory.py
@@ -51,13 +51,20 @@ def _read_json(path: Path, default):
         return default
 
 
+def _write_atomic(path: Path, data: str) -> None:
+    """Write via temp + os.replace so a concurrent reader never sees a half-file."""
+    tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
+    tmp.write_text(data, encoding="utf-8")
+    os.replace(tmp, path)
+
+
 def _write_edges() -> None:
     """Cache the proven-edge table to edges.json for the onchain card + dashboard."""
     cells = summary(None)["table"]
     edges = [{"t": c["technique"], "r": c["regime"], "e": c["expectancy_r"],
               "n": c["trades"], "real": c["edge_real"]}
              for c in cells if c["trades"] >= 3][:12]
-    (home() / "edges.json").write_text(json.dumps(edges), encoding="utf-8")
+    _write_atomic(home() / "edges.json", json.dumps(edges))
 
 
 def record(args: argparse.Namespace) -> dict:

--- a/scripts/predict.js
+++ b/scripts/predict.js
@@ -33,6 +33,10 @@ const DIR = path.join(GCLAW_HOME, 'predictions');
 const SKILL_DIR = path.join(os.homedir(), '.claude', 'skills', 'gclaw', 'scripts');
 
 const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+// Atomic write — the 2-min Telegram poll reads these files concurrently; a direct
+// writeFileSync truncates-then-writes, so a concurrent reader can catch a half-file
+// and drop a call. temp + rename is atomic on the same filesystem.
+const writeAtomic = (p, data) => { const t = `${p}.tmp${process.pid}`; fs.writeFileSync(t, data); fs.renameSync(t, p); };
 const readJsonl = (p) => { try { return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l)); } catch { return []; } };
 const agentId = () => String(readJson(path.join(GCLAW_HOME, 'metabolism.json'), {}).onchain_identity?.agentId || '0');
 const managed = () => JSON.parse(fs.readFileSync(WALLET_PATH, 'utf8')).managed?.['Arbitrum (HyperLiquid)']?.address;
@@ -81,7 +85,7 @@ function writeRoot() {
   const payload = open.map((r) => ({ id: r.id, coin: r.coin, side: r.side, entry: r.entry, openedAt: r.openedAt,
     calls: calls.filter((c) => c.roundId === r.id).map((c) => `${c.by}:${c.pick}:${c.ts}`).sort() }));
   const root = ethers.id(JSON.stringify(payload));
-  fs.writeFileSync(path.join(DIR, 'root.json'), JSON.stringify({ root, openRounds: open.map((r) => r.id), updatedAt: new Date().toISOString() }, null, 2) + '\n');
+  writeAtomic(path.join(DIR, 'root.json'), JSON.stringify({ root, openRounds: open.map((r) => r.id), updatedAt: new Date().toISOString() }, null, 2) + '\n');
   return root;
 }
 
@@ -101,7 +105,7 @@ async function cmdOpen(args) {
       openedAt: new Date().toISOString(), status: 'open', outcome: null };
     opened.push(rounds[id]);
   }
-  fs.writeFileSync(roundsPath(), JSON.stringify(rounds, null, 2));
+  writeAtomic(roundsPath(), JSON.stringify(rounds, null, 2));
   writeRoot();
   if (args.announce) for (const r of opened) await announce(`🎯 ${soulName()} just opened ${r.coin} ${r.side} @ $${r.entry}.\nCall it — reply TP or SL. (round ${r.id})`);
   return { ok: true, opened, openRounds: Object.values(rounds).filter((r) => r.status === 'open').map((r) => ({ id: r.id, coin: r.coin, side: r.side })) };
@@ -152,8 +156,8 @@ async function cmdResolve(args) {
       await announce(`🏁 ${soulName()}'s ${r.coin} → ${outcome} (${r.pnl >= 0 ? '+' : ''}$${r.pnl}).\n${who}`);
     }
   }
-  fs.writeFileSync(roundsPath(), JSON.stringify(rounds, null, 2));
-  fs.writeFileSync(predictorsPath(), JSON.stringify(predictors, null, 2));
+  writeAtomic(roundsPath(), JSON.stringify(rounds, null, 2));
+  writeAtomic(predictorsPath(), JSON.stringify(predictors, null, 2));
   writeRoot();
   return { ok: true, resolved };
 }

--- a/scripts/predict_bot.js
+++ b/scripts/predict_bot.js
@@ -111,13 +111,18 @@ async function poll(timeoutSec) {
   let upd = await tg('getUpdates', params, (timeoutSec || 0) * 1000 + 15000);
   if (!upd || !upd.ok) upd = await tg('getUpdates', params, (timeoutSec || 0) * 1000 + 15000); // one retry on a transient null
   if (!upd || !upd.ok) return { ok: false, error: 'getUpdates failed' };
-  let processed = 0;
-  for (const u of upd.result) {
-    off.offset = u.update_id + 1;
-    if (u.message) { await handle(u.message); processed += 1; }
-  }
   fs.mkdirSync(DIR, { recursive: true });
-  fs.writeFileSync(OFFSET_PATH, JSON.stringify(off));
+  let processed = 0;
+  // Advance the offset only AFTER an update is handled, and persist it atomically
+  // per-update. Telegram permanently drops updates below a committed offset, so
+  // committing before handling would silently lose a user's call on any failure.
+  for (const u of upd.result) {
+    try { if (u.message) { await handle(u.message); processed += 1; } }
+    catch { break; } // leave the offset before this update so Telegram redelivers it
+    off.offset = u.update_id + 1;
+    const tmp = `${OFFSET_PATH}.tmp${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(off)); fs.renameSync(tmp, OFFSET_PATH);
+  }
   return { ok: true, processed };
 }
 

--- a/scripts/riskguard.js
+++ b/scripts/riskguard.js
@@ -73,6 +73,48 @@ function assess(st) {
   });
 }
 
+const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return d; } };
+const writeAtomic = (p, data) => { const t = `${p}.tmp${process.pid}`; fs.writeFileSync(t, data); fs.renameSync(t, p); };
+
+// Janitor: position-keyed state files (open_risk, riskguard_exempt) are written at
+// entry but never cleaned, so a stale entry mis-attributes the next trade or
+// silently exempts a re-entry from the cap. Drop any entry with no matching live
+// position so each only ever describes trades that actually exist.
+function pruneState(positions) {
+  const liveAt = (coin, entry) => positions.some((p) => p.coin === coin
+    && Math.abs(Number(p.entryPx) - Number(entry)) / Number(p.entryPx) < 0.001);
+  const liveCoin = new Set(positions.map((p) => p.coin));
+  const exPath = path.join(GCLAW_HOME, 'riskguard_exempt.json');
+  const exempt = readJson(exPath, null);
+  if (Array.isArray(exempt)) {
+    const kept = exempt.filter((e) => liveAt(e.coin, e.entry));
+    if (kept.length !== exempt.length) writeAtomic(exPath, JSON.stringify(kept));
+  }
+  const orPath = path.join(GCLAW_HOME, 'open_risk.json');
+  const orisk = readJson(orPath, null);
+  if (orisk && typeof orisk === 'object') {
+    const kept = Object.fromEntries(Object.entries(orisk).filter(([coin]) => liveCoin.has(coin)));
+    if (Object.keys(kept).length !== Object.keys(orisk).length) writeAtomic(orPath, JSON.stringify(kept));
+  }
+}
+
+// Deterministic circuit breaker: halt + flatten everything on a drawdown from the
+// high-water mark. The advisory forge breaker was never enforced; this is.
+function breakerCheck(eq, positions, dry) {
+  const bpath = path.join(GCLAW_HOME, 'breaker.json');
+  const dd = Number(process.env.GCLAW_BREAKER_DD) || 0.25;
+  const prev = readJson(bpath, {});
+  const hwm = Math.max(Number(prev.hwm) || eq, eq);
+  const drawdown = hwm > 0 ? (hwm - eq) / hwm : 0;
+  const tripped = drawdown >= dd;
+  if (!dry) {
+    writeAtomic(bpath, JSON.stringify({ hwm: Math.round(hwm * 100) / 100, equity: Math.round(eq * 100) / 100,
+      drawdown_pct: Math.round(drawdown * 1000) / 10, tripped, reason: tripped ? `drawdown ${(drawdown * 100).toFixed(1)}% >= ${dd * 100}%` : null,
+      at: new Date().toISOString() }, null, 2) + '\n');
+  }
+  return { hwm, drawdown, tripped };
+}
+
 function reduce(coin, size, dry) {
   if (dry) return { coin, wouldReduce: Number(size.toFixed(6)) };
   return hl(['close', '--coin', coin, '--size', String(size)]);
@@ -88,6 +130,15 @@ function enforce(dry) {
   if (!st) return { ok: true, skipped: 'status read unavailable this cycle' };
   const eq = Number(st.equity) || 0;
   if (!eq) return { ok: false, error: 'no equity read' };
+  if (!dry) pruneState(st.positions || []); // clean stale position-keyed state first
+
+  // Circuit breaker: on a drawdown halt, flatten EVERYTHING (exemptions don't apply
+  // to a breaker) and stop — no per-trade fiddling when the book must be de-risked.
+  const brk = breakerCheck(eq, st.positions || [], dry);
+  if (brk.tripped) {
+    const actions = (st.positions || []).map((p) => ({ coin: p.coin, reason: `BREAKER drawdown ${(brk.drawdown * 100).toFixed(1)}%`, action: flatten(p.coin, dry) }));
+    return { ok: true, dry: !!dry, equity: Math.round(eq * 100) / 100, breaker_tripped: true, drawdown_pct: Math.round(brk.drawdown * 1000) / 10, actions };
+  }
   const cap = eq * (RISK_CAP_PCT / 100);
   const portCap = eq * (PORTFOLIO_CAP_PCT / 100);
   const actions = [];


### PR DESCRIPTION
Closes the HIGH/MED findings from the parallel security/correctness/concurrency audit (the two CRITICALs shipped in v3.4.2):

- **H1** gmac_buy decrements the treasury itself on confirmed buy (no model-dependent double-spend).
- **H2** autosettle advances the cursor before settle + atomic write (no double-book on crash).
- **H3** Telegram offset advances only after handling, persisted atomically per-update (no silently-lost calls).
- **M1/M2/M4** riskguard prunes stale open_risk/exempt to live positions, and **enforces** the circuit breaker (flatten at 25% drawdown) that was advisory-only.
- **M3** atomic writes of rounds/root/predictors/edges (no truncated read → dropped call).
- **M5** evolve.py atomic save_state (no metabolism corruption mid-evolve).
- **M6** removed manual settle/royalty/gmac-spend from SKILL.md (autosettle + gmac_buy do them; manual double-counted).

Verified: all lint clean; riskguard prune+breaker run live (no trades, breaker HWM recorded, ETH exemption preserved); autosettle/memory/evolve all run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)