### PR TITLE
Cache per-heartbeat status read + expire stale prediction rounds

### DIFF
--- a/scripts/autotrail.js
+++ b/scripts/autotrail.js
@@ -47,7 +47,7 @@ function positions() {
   // Best-effort: a transient status failure means "nothing to trail this cycle"
   // (the hard exchange SL still protects), never an error that noise-spams the log.
   try {
-    const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status'], { encoding: 'utf8', timeout: 90000 });
+    const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status', '--cache'], { encoding: 'utf8', timeout: 90000 });
     return JSON.parse(out.trim().split('\n').pop()).positions || [];
   } catch {
     return [];

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -308,14 +308,41 @@ async function cmdCancel(wallet, args) {
   return { ok: true, action: 'cancel', coin, oid: String(args.oid) };
 }
 
+// Cache the status read so the several callers in one heartbeat (autotrail,
+// model_select, riskguard, predict) share a single network fetch. The 90s TTL is
+// short enough that the post-LLM callers re-read fresh state (the LLM cycle takes
+// minutes), so a trade just opened is never served stale.
+const STATUS_CACHE = path.join(process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw'), 'status_cache.json');
+const STATUS_TTL_MS = 90000;
+
+function readStatusCache() {
+  try {
+    const c = JSON.parse(fs.readFileSync(STATUS_CACHE, 'utf8'));
+    return Date.now() - c.ts < STATUS_TTL_MS ? c.data : null;
+  } catch { return null; }
+}
+
+function writeStatusCache(data) {
+  try {
+    const tmp = `${STATUS_CACHE}.tmp${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify({ ts: Date.now(), data }));
+    fs.renameSync(tmp, STATUS_CACHE);
+  } catch { /* cache is best-effort */ }
+}
+
 async function main() {
   const [cmd, ...rest] = process.argv.slice(2);
   const args = parseArgs(rest);
+  if (cmd === 'status' && args.cache) {
+    const cached = readStatusCache();
+    if (cached) { process.stdout.write(JSON.stringify(cached) + '\n'); return; }
+  }
   const wallet = loadWallet();
   const handlers = { status: cmdStatus, open: cmdOpen, close: cmdClose, cancel: cmdCancel };
   const handler = handlers[cmd];
   if (!handler) die(`unknown command '${cmd}'. Use: status | open | close`);
   const result = await handler(wallet, args);
+  if (cmd === 'status' && result.ok) writeStatusCache(result); // never cache a failed/partial read
   process.stdout.write(JSON.stringify(result) + '\n');
 }
 

--- a/scripts/model_select.js
+++ b/scripts/model_select.js
@@ -25,7 +25,7 @@ const readJson = (p, d) => { try { return JSON.parse(fs.readFileSync(p, 'utf8'))
 
 function positionCount() {
   try {
-    const out = execFileSync('node', [path.join(__dirname, 'hl_perp.js'), 'status'],
+    const out = execFileSync('node', [path.join(__dirname, 'hl_perp.js'), 'status', '--cache'],
       { encoding: 'utf8', timeout: 60000 });
     return (JSON.parse(out.trim().split('\n').pop()).positions || []).length;
   } catch { return 0; }

--- a/scripts/predict.js
+++ b/scripts/predict.js
@@ -54,7 +54,7 @@ function hlInfo(body) {
 function position() {
   const { execFileSync } = require('node:child_process');
   try {
-    const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status'], { encoding: 'utf8', timeout: 90000 });
+    const out = execFileSync('node', [path.join(SKILL_DIR, 'hl_perp.js'), 'status', '--cache'], { encoding: 'utf8', timeout: 90000 });
     return JSON.parse(out.trim().split('\n').pop());
   } catch { return { positions: [], openOrders: [] }; }
 }
@@ -136,8 +136,17 @@ async function cmdResolve(args) {
   const calls = readJsonl(callsPath());
   const predictors = readJson(predictorsPath(), {});
   const resolved = [];
+  const expired = [];
+  const ttlMs = (Number(process.env.GCLAW_ROUND_TTL_DAYS) || 14) * 24 * 3600 * 1000;
   for (const r of open) {
-    if (live.has(r.coin)) continue; // still running
+    if (live.has(r.coin)) {
+      // A coin that's still (or perpetually) a live position can't resolve. Expire
+      // a stale one so it stops bloating the root + open list forever. No scoring.
+      if (Date.now() - new Date(r.openedAt).getTime() > ttlMs) {
+        r.status = 'expired'; r.resolvedAt = new Date().toISOString(); expired.push(r.id);
+      }
+      continue;
+    }
     const since = new Date(r.openedAt).getTime();
     const close = fills.filter((f) => f.coin === r.coin && Number(f.closedPnl || 0) !== 0 && f.time >= since)
       .reduce((s, f) => s + Number(f.closedPnl), 0);
@@ -159,7 +168,7 @@ async function cmdResolve(args) {
   writeAtomic(roundsPath(), JSON.stringify(rounds, null, 2));
   writeAtomic(predictorsPath(), JSON.stringify(predictors, null, 2));
   writeRoot();
-  return { ok: true, resolved };
+  return { ok: true, resolved, ...(expired.length ? { expired } : {}) };
 }
 
 function cmdLeaderboard() {


### PR DESCRIPTION
The two LOW audit items.

- **Status caching:** `hl_perp.js status --cache` serves a <90s cached read so the cluster of callers in one heartbeat (autotrail, model_select, predict) shares a single GDEX sign-in instead of four — directly cuts the transient/rate-limit failure surface. Only successful reads are cached; 90s TTL keeps post-LLM callers fresh; **riskguard stays uncached** (the safety guardrail always reads live) and its fetch repopulates the cache.
- **Round TTL:** a still-open round on a perpetually-live coin expires after `GCLAW_ROUND_TTL_DAYS` (default 14) instead of leaking into the root + open list forever.

Verified: fresh cache served without a sign-in, stale (>90s) ignored, TTL expiry logic correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)