### PR TITLE
Don't trip the circuit breaker on a zero/failed equity read

### DIFF
--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -1000,6 +1000,10 @@ def circuit_breaker(equity: float, n_positions: int) -> dict[str, Any]:
         state = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         pass
+    # A failed/rate-limited status read passes equity<=0; never trip (or move the
+    # high-water mark) on a bad read — that would falsely flatten / alert at 100%.
+    if equity <= 0:
+        return {**state, "tripped": bool(state.get("tripped")), "skipped": "no equity read"}
     hwm = max(float(state.get("hwm", 0) or 0), equity)
     drawdown_pct = round((1 - equity / hwm) * 100, 2) if hwm > 0 else 0.0
     reason = None


### PR DESCRIPTION
A rate-limited status read passes `equity<=0` to `forge.py`'s `circuit_breaker`, which computed `(hwm-0)/hwm = 100%` drawdown → `tripped=true` (a false trip → bogus alert). Guard `equity<=0`: skip without moving the HWM or changing tripped state. riskguard's enforcer already returns before its breaker on a zero read (no flatten risk); this stops the false alert at the source. Reset the stale false-trip in runtime state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)