### PR TITLE
Quant fixes: regime calibration, look-ahead, reproducible stats, net edge

### DIFF
--- a/dna/TRADING_STRATEGY.md
+++ b/dna/TRADING_STRATEGY.md
@@ -80,8 +80,9 @@ You have a perception + risk stack. **Use it; do not trade on a raw price glance
      the sole reason to enter.
 5. **Size with the risk brain, never by gut** —
    `node scripts/sizing.py size --equity <E> --price <P> --atr-pct <atr_pct> --win-rate <w>
-   --payoff <b> --goodwill <g> --confidence <c>` (pull `--win-rate`/`--payoff` from
-   `memory.py expectancy --technique <t> --regime <r>`). Open with exactly the returned `notional`,
+   --payoff <b> --trades <n> --goodwill <g> --confidence <c>` (pull `--win-rate`/`--payoff`/`--trades`
+   from `memory.py expectancy --technique <t> --regime <r>`; `--trades` lets it shrink a small-sample
+   win-rate toward 0.5 so noise isn't sized up). Open with exactly the returned `notional`,
    `size`, and ATR-based stop. This caps any single trade's risk to a fixed fraction of equity —
    no trade can dominate the P&L again. At entry, write the risk **and a short thesis label**
    to `~/.gclaw/open_risk.json` (`{"<coin>": {"risk": <usd>, "technique": "<short-label>"}}`) so

--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -181,10 +181,11 @@ async function main() {
         const risk = labelled.risk || notional * 0.015 || 0.25; // sized risk, else 1.5%-stop estimate
         const tech = technique || labelled.technique || 'discretionary';
         const side = String(f.dir || '').includes('Short') ? 'short' : 'long';
+        const netPnl = Number(f.closedPnl) - Number(f.fee || 0); // expectancy must be net of fees, not gross
         execFileSync('uv', ['run', '--no-project', 'python3', path.join(__dirname, 'memory.py'),
           'record', '--coin', String(f.coin), '--technique', String(tech),
           '--regime', regimes[f.coin] || 'unknown', '--side', side,
-          '--pnl', String(f.closedPnl), '--risk', String(risk)],
+          '--pnl', String(netPnl), '--risk', String(risk)],
         { env: { ...process.env, GCLAW_HOME }, stdio: ['ignore', 'ignore', 'ignore'] });
       } catch { /* memory record is best-effort */ }
     }

--- a/scripts/intel.js
+++ b/scripts/intel.js
@@ -110,15 +110,21 @@ async function fundingZ(coin) {
 }
 
 function classifyRegime(f) {
-  // trend when price moves efficiently; chop when it thrashes at high vol; else range.
-  if (f.atr_pct > 4 && f.efficiency < 0.3) return 'chop';
-  if (f.efficiency >= 0.4) return f.ema_stack >= 0 ? 'trend_up' : 'trend_down';
-  if (f.efficiency < 0.25) return 'range';
-  return f.ema_stack > 0 ? 'trend_up' : (f.ema_stack < 0 ? 'trend_down' : 'range');
+  // Classify on the Kaufman efficiency ratio (net move / total path) — scale- and
+  // timeframe-free, unlike an absolute ATR threshold (1h ATR is ~1%, so the old
+  // atr>4% chop test never fired). High ER = clean trend; very low ER = whipsaw to
+  // sit out; the middle is an orderly range where mean-reversion has an edge.
+  const trendER = Number(process.env.GCLAW_TREND_ER) || 0.40;
+  const chopER = Number(process.env.GCLAW_CHOP_ER) || 0.18;
+  if (f.efficiency >= trendER) return f.ema_stack >= 0 ? 'trend_up' : 'trend_down';
+  if (f.efficiency < chopER) return 'chop';
+  return 'range';
 }
 
 async function coinIntel(coin, ctx, btcReturns) {
-  const c1 = await candles(coin, '1h', 120);
+  // Drop the last (currently-forming) candle — its OHLC mutates intra-hour, so
+  // every indicator built on it would jitter and the "close" isn't a real close.
+  const c1 = (await candles(coin, '1h', 121)).slice(0, -1);
   if (c1.length < 30) return null;
   const closes = c1.map((k) => k.c);
   const e9 = ema(closes.slice(-40), 9); const e21 = ema(closes.slice(-60), 21); const e50 = ema(closes, 50);
@@ -154,7 +160,7 @@ async function scan(coins) {
   const ctxResp = await info({ type: 'metaAndAssetCtxs' });
   const ctxByName = new Map();
   if (Array.isArray(ctxResp) && ctxResp[0]?.universe) ctxResp[0].universe.forEach((u, i) => ctxByName.set(u.name, ctxResp[1][i]));
-  const btc = await candles('BTC', '1h', 48);
+  const btc = (await candles('BTC', '1h', 49)).slice(0, -1); // closed bars only
   const btcReturns = returns(btc.map((k) => k.c).slice(-24));
   const out = {};
   for (const coin of coins) out[coin] = await coinIntel(coin, ctxByName.get(coin), btcReturns);

--- a/scripts/memory.py
+++ b/scripts/memory.py
@@ -116,13 +116,19 @@ def swarm(_args: argparse.Namespace) -> dict:
 
 
 def _bootstrap_ci(rs: list[float], iters: int = 2000) -> tuple[float, float]:
-    """95% CI on the mean R via bootstrap resampling — is the edge real or luck?"""
+    """95% CI on the mean R via bootstrap resampling — is the edge real or luck?
+
+    Seed the RNG from the data so the CI (and the edge_real gate it drives) is
+    reproducible: the same trade history must always give the same verdict, never
+    a coin-flip between runs for a technique sitting near the significance boundary.
+    """
     if len(rs) < 3:
         return (0.0, 0.0)
+    rng = random.Random(hash(tuple(round(r, 4) for r in rs)) & 0xFFFFFFFF)
     means = []
     n = len(rs)
     for _ in range(iters):
-        means.append(sum(rs[int(random.random() * n)] for _ in range(n)) / n)
+        means.append(sum(rs[int(rng.random() * n)] for _ in range(n)) / n)
     means.sort()
     return (round(means[int(0.025 * iters)], 3), round(means[int(0.975 * iters)], 3))
 

--- a/scripts/sizing.py
+++ b/scripts/sizing.py
@@ -38,6 +38,16 @@ def leverage_cap(goodwill: float) -> int:
     return cap
 
 
+SHRINK_PSEUDO = 20  # pseudo-trades pulling a small-sample win-rate toward 0.5
+
+
+def shrink_win_rate(win_rate: float, trades: int) -> float:
+    """Shrink a small-sample win-rate toward 0.5 so we don't size up on noise: a
+    Beta(k/2, k/2) prior, w_adj = (w*n + 0.5*k) / (n + k). 70% on 5 trades → ~0.54."""
+    n = max(0, int(trades))
+    return (win_rate * n + 0.5 * SHRINK_PSEUDO) / (n + SHRINK_PSEUDO)
+
+
 def kelly_fraction(win_rate: float, payoff: float) -> float:
     """Edge as a fraction of bankroll: f* = W - (1-W)/b, then quarter it."""
     if payoff <= 0:
@@ -47,11 +57,11 @@ def kelly_fraction(win_rate: float, payoff: float) -> float:
 
 
 def size_trade(equity: float, price: float, atr_pct: float, win_rate: float,
-               payoff: float, goodwill: float, confidence: float) -> dict:
+               payoff: float, goodwill: float, confidence: float, trades: int = 0) -> dict:
     """Return the position size, stop, and risk for one trade."""
     stop_pct = max(STOP_ATR_MULT * atr_pct, 0.8) / 100  # never tighter than 0.8%
-    # risk fraction: base, scaled by Kelly edge and the signal's confidence.
-    edge = kelly_fraction(win_rate, payoff)
+    # risk fraction: base, scaled by the (sample-shrunk) Kelly edge and confidence.
+    edge = kelly_fraction(shrink_win_rate(win_rate, trades), payoff)
     # an unknown/zero edge still gets a tiny probe; a real edge scales toward base.
     risk_pct = min(BASE_RISK_PCT, max(0.0015, edge)) * max(0.3, min(1.0, confidence))
     risk_usd = equity * risk_pct
@@ -71,6 +81,7 @@ def size_trade(equity: float, price: float, atr_pct: float, win_rate: float,
         "risk_usd": round(realized_risk, 2),
         "risk_pct_equity": round(realized_risk / equity * 100, 2) if equity else 0,
         "kelly_edge": round(edge, 4),
+        "win_rate_shrunk": round(shrink_win_rate(win_rate, trades), 3),
         "leverage_cap": leverage_cap(goodwill),
         "clamped_to_min": notional <= MIN_NOTIONAL + 1e-9,
         "note": "sized to risk a fixed fraction of equity; size falls out of the ATR stop",
@@ -87,8 +98,9 @@ def main() -> int:
     p.add_argument("--payoff", type=float, default=1.5)
     p.add_argument("--goodwill", type=float, default=0)
     p.add_argument("--confidence", type=float, default=0.6)
+    p.add_argument("--trades", type=int, default=0, help="sample size behind win-rate (for shrinkage)")
     a = p.parse_args()
-    out = size_trade(a.equity, a.price, a.atr_pct, a.win_rate, a.payoff, a.goodwill, a.confidence)
+    out = size_trade(a.equity, a.price, a.atr_pct, a.win_rate, a.payoff, a.goodwill, a.confidence, a.trades)
     print(json.dumps(out, indent=2))
     return 0
 


### PR DESCRIPTION
Quant review of the trading math — four real defects:

- **Chop gate was dead** (`intel.js`): `atr_pct > 4%` never fires on 1h majors (ATR ~1%), so whipsaw tape fell through to `range` and got traded — the source of the bleed. Reclassify on the **Kaufman efficiency ratio** (scale/timeframe-free): ER≥0.40 trend, ER<0.18 chop, else range. **Live majors now correctly read chop (ER 0.03–0.08)** — exactly the tape the shorts are bleeding in.
- **Look-ahead/jitter**: drop the forming candle; indicators use closed bars only.
- **Non-reproducible gate** (`memory.py`): seed the bootstrap from the data so `edge_real` can't flip between runs.
- **Gross vs net edge** (`autosettle.js`): record post-fee PnL to memory; expectancy was overstated.
- **Small-sample over-betting** (`sizing.py`): shrink win-rate toward 0.5 (Beta prior, 20 pseudo-trades); `--trades` wired through the DNA.

Verified: regime fires chop on live whipsaw; CI reproducible; shrinkage halves a 5-trade edge estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)