### PR TITLE
Docs: bring README + dev guide current

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,28 @@ with `gdex_sign.js` providing the one local signature managed custody can't dele
 | path | role |
 |------|------|
 | `SKILL.md` | entry point — trigger + heartbeat procedure |
-| `dna/` | the agent's DNA template (copied to `~/.gclaw/dna` on first run) |
-| `scripts/metabolism.py` | survival state machine — `init/status/tick/charge/settle` |
+| `dna/` | the agent's DNA template (copied to `~/.gclaw/dna` on first run); `TRADING_STRATEGY.md` is the trading brain |
+| `scripts/heartbeat.sh` | the unattended cron loop — sequences every deterministic step around the LLM cycle |
+| `scripts/metabolism.py` | survival state machine — `init/status/tick/charge/settle/gmac` (atomic writes) |
 | `scripts/evolve.py` | goodwill-gated `replicate/recode/capabilities` |
+| **Perception & risk** | |
+| `scripts/intel.js` | perception + **regime** engine (EMA/RSI/ATR/Bollinger-z/funding-z/BTC-corr → trend/range/chop) |
+| `scripts/sizing.py` | vol-targeted + fractional-Kelly position sizing (sample-shrunk) |
+| `scripts/memory.py` | trade-memory — regime-conditional expectancy w/ bootstrap CI; `swarm` pools the family |
+| `scripts/riskguard.js` | **deterministic** per-trade/portfolio risk cap + naked-flatten + drawdown breaker (enforces, not advises) |
+| `scripts/model_select.js` | hybrid model + adaptive cadence — Opus only when active, else Sonnet |
+| **Execution & settlement** | |
 | `scripts/gdex_sign.js` | instant local sign-in signer (pure crypto) |
-| `scripts/hl_perp.js` | SDK fallback executor (`status/open/close`) |
-| `scripts/forge.py` + `scripts/forge_data.js` | technique forge — author/prove/adopt/run self-made trading skills |
-| `references/` | `mcp-trading.md` (primary), `trading.md`, `metabolism.md`, `evolution.md` |
+| `scripts/hl_perp.js` | SDK executor (`status [--cache] / open / close [--size]`) |
+| `scripts/autofund.js` · `autotrail.js` · `autosettle.js` · `gmac_buy.js` | deterministic funding, trailing stops, settlement (atomic/idempotent), GMAC buy-back |
+| `scripts/forge.py` + `scripts/forge_data.js` | technique forge — author/prove/adopt/run self-made skills (AST-sandboxed) |
+| **Identity, social & UI** | |
+| `scripts/erc8004_register.js` · `peers.js` · `stats.js` | onchain ERC-8004 card/beacon, family discovery, IPFS leaderboard |
+| `scripts/predict.js` + `predict_bot.js` | the "Call it" prediction game engine + Telegram input |
+| `scripts/notify.js` | health alerts + in-voice win/milestone texts (webhook + Telegram) |
+| `scripts/dashboard.py` | the tabbed living dashboard (vitals, P&L sparkline, regime, predictions) |
+| `leaderboard/leaderboard.html` | the decentralized, unhosted leaderboard (reads the chain directly) |
+| `references/` | `mcp-trading.md` (primary), `trading.md`, `metabolism.md`, `evolution.md`, `safety.md`, `family.md` |
 
 ## Build / test / lint
 
@@ -44,6 +59,15 @@ node scripts/gdex_sign.js                              # instant, prints a signe
 - Every perp entry carries a stop. The $11 HL min notional is enforced.
 - The GMAC balance changes ONLY through `metabolism.py`; PnL is settled ONLY from real closed positions.
 - Majors first (BTC/ETH/SOL), low size, conservative leverage. No memecoins.
+- **Safety is deterministic, never advisory.** Risk caps (`riskguard.js`), settlement
+  (`autosettle.js`), GMAC spend (`gmac_buy.js`), and the drawdown breaker run as code the
+  model can't skip — that's the lesson from every audit. Don't "fix" a safety gap by adding
+  a model instruction; enforce it in a script.
+- **No drain surface.** The heartbeat denies every fund-moving / arbitrary-token / copy-trade
+  MCP tool; the forge sandbox blocks introspection-attribute escapes. Re-check both when
+  touching `heartbeat.sh` deny-list or `forge.py` validators.
+- The agent trades on the **regime** (`intel.js`): no entries in `chop`; size via `sizing.py`;
+  open only on memory-proven, regime-matched edge.
 
 ## Issue tracking — beads
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ That's it. `install.sh` makes you a fresh managed-custody wallet and prints the 
 | `gclaw fund` | has the money landed yet? |
 | `gclaw start` | bring the creature to life (birth + hourly heartbeat) |
 | `gclaw status` | how it's doing right now |
-| `gclaw dashboard` | open its living DNA page |
+| `gclaw dashboard` | open its tabbed vitals dashboard (equity, P&L trend, regime, predictions) |
 | `gclaw talk <name>` | talk to a creature in character |
 | `gclaw beat` | run one heartbeat now |
 
@@ -71,10 +71,22 @@ Kill switch any time: `touch ~/.gclaw/PAUSE` (and `rm` it to resume).
 
 ## // What it actually does
 
-Every hour, on its own, your creature: ticks its GMAC life-energy, reads the
-HyperLiquid market, and — only with a real edge — opens one small, **always
-stop-protected** trade (perps or HIP-3 event markets). It books its own PnL,
-earns goodwill, and as goodwill grows it unlocks:
+Every heartbeat, on its own, your creature reads the HyperLiquid market into a
+**regime** (trend / range / chop) and acts on the read, not a hunch:
+
+- **Sits out the chop.** In directionless whipsaw it does nothing — the simplest way
+  to stop donating to noise.
+- **Trades only proven, regime-matched edge.** It opens a trade only when a technique
+  has positive expectancy *in the current regime* from its own **trade-memory** — a
+  self-learning record (with a bootstrap confidence gate) of what works in which
+  conditions, pooled across the whole family.
+- **Sizes with math, not gut.** Every trade is **volatility-targeted + fractional-Kelly**
+  sized — proven edges scale up, coin-flips drop to the floor — and **always carries a stop.**
+- **Can't blow up.** A deterministic **risk guardrail** runs every heartbeat: it
+  physically trims any position over its risk cap, flattens naked (stopless) ones, and
+  halts on a drawdown breaker. Safety is enforced in code, never left to the model.
+
+It books its own PnL, earns goodwill, and as goodwill grows it unlocks:
 
 | goodwill | unlocks |
 |---|---|
@@ -85,6 +97,15 @@ earns goodwill, and as goodwill grows it unlocks:
 
 Profit feeds back: 10% of every win is earmarked to **buy real GMAC**. Its whole
 arc bends toward one thing — turning earned success into unstoppable GMAC accumulation.
+
+## // Call it — the free prediction game
+
+When your creature opens a trade, anyone can **call it — TP or SL** for free: no
+stake, no funds held, ever. Calls are hashed and anchored onchain *before* the trade
+resolves, and the outcome is read from HyperLiquid's own fills — so nobody, not even
+the operator, can backdate a call or fudge a result. Correct callers climb a **global
+predictors ladder** pooled across every creature. Reply right in Telegram; the points
+are pure clout (never money, never redeemable) — so it's engagement, not gambling.
 
 ## // Decentralized by design · Built on Base
 
@@ -112,9 +133,14 @@ the chain directly — **no server, no host.** Open it from the repo or pin it t
 
 ## // Under the hood
 
-Claude Code is the runtime; the GDEX MCP is the trading arm; deterministic Python
-owns the survival bookkeeping so the agent can't lie to itself. See `SKILL.md` for
-the heartbeat, `CLAUDE.md` for development, and `references/` for the playbooks.
+Claude Code is the runtime; the GDEX MCP is the trading arm. Every safety- and
+money-critical step is **deterministic Python/Node the model can't skip** — position
+sizing, the risk guardrail, settlement, the circuit breaker, GMAC buy-backs — so the
+agent can't lie to itself or be talked into a drain. To respect cost it runs **Sonnet
+by default and escalates to Opus only when a trade is actually on the table**, and
+stretches its cadence when flat. See `SKILL.md` for the heartbeat,
+`dna/TRADING_STRATEGY.md` for the trading brain, `CLAUDE.md` for development, and
+`references/` for the playbooks.
 
 > Requires Node 22+, Python 3, and the GDEX SDK (`GemachDAO/gdex-skill`). Trading
 > uses real money — start small. Your wallet's secrets live in `~/.gclaw/wallet.json`


### PR DESCRIPTION
The docs predated the trading-intelligence stack, the prediction game, and the safety hardening.

- **README** 'what it does': the intelligent loop — regime read (sits out chop), memory-proven regime-matched edge, vol-targeted/Kelly sizing, deterministic risk guardrail. New 'Call it' prediction-game section + hybrid Sonnet/Opus & adaptive-cadence note.
- **CLAUDE.md**: script Layout table now covers the full stack (intel/sizing/memory/riskguard/model_select, autofund/trail/settle/gmac_buy, erc8004/peers/stats/predict/predict_bot/notify/dashboard/leaderboard). New invariants: 'safety is deterministic, not advisory' + the no-drain surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)