### PR TITLE
Close the trading gaps: perp-collateral sizing, riskguard cap, maker entries

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -75,11 +75,15 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
    `uv run --no-project python3 scripts/telepathy.py inbox` (act on fresh trade_signal/warning).
    Read live exposure via `mcp__gdex__get_hl_clearinghouse_state {userAddress: <managed>}`,
    `get_hl_spot_state`, and `get_hl_open_orders` — the source of truth for positions and free capital.
-   **Capital gauge:** HL keeps ONE unified USDC balance. Free buying power for a new
-   trade is `node scripts/hl_perp.js status` → `buyingPower` (spot USDC `total − hold`),
-   NOT perp `withdrawable`/`accountValue` (those only show margin already committed and
-   read ~$0 even when the account is fully funded). Deposits land in spot; HL pledges
-   margin from it automatically when a perp is opened — there is no spot→perp transfer.
+   **Capital gauge:** HL keeps spot and perp as SEPARATE wallets. `node scripts/hl_perp.js
+   status` reports both: `buyingPower` (spot USDC `total − hold`) and `withdrawable` (free
+   PERP collateral). Spot USDC is NOT auto-pledged as perp margin — a new perp draws margin
+   ONLY from the perp wallet, so its capacity is `withdrawable`, not `buyingPower`. If perp
+   `withdrawable` is ~$0 while spot holds the balance, no perp can open until the perp wallet
+   is funded. The gdex backend has NO spot→perp transfer (`hl_deposit` bridges external
+   Arbitrum USDC into perp; `hl_swap_collateral` swaps dex tokens) and gclaw cannot sign an
+   HL `usdClassTransfer` locally (funds sit under the managed account, whose key it does not
+   hold), so perp funding needs an external deposit or gdex backend support (assune-4fw.5).
 4. **Reconcile closes (auto).** Run `node scripts/autosettle.js run` — it books realized PnL from any
    closes (TP/SL or manual) by reading HL fills, netting `closedPnl − fee`, and calling `metabolism.py
    settle` exactly once per close (cursor-deduped; safe if the cron already ran it). Don't settle trade

--- a/references/2026-07-fee-wall-and-gate-fix.md
+++ b/references/2026-07-fee-wall-and-gate-fix.md
@@ -79,11 +79,16 @@ maker (~1.5bp), so the round trip the edge must beat is ~3bp, not ~15bp.
   slippage) and `MAKER_FEE = 0.00015` (1.5bp, no slippage). `round_trip_cost(stop_hit)`
   charges: entry = maker if `GCLAW_FORGE_MAKER_ENTRY=1` else taker; exit = taker if the
   stop was hit (a trigger always crosses the book) else it fills like the entry.
-- **Backtest matches the live executor.** `hl_perp.js` opens `isMarket:true` (taker), so
-  the backtest DEFAULT (flag unset) charges taker on both legs = 15bp — identical to
-  today's fills. A cross-referenced comment in both files requires flipping
-  `isMarket:false` and `GCLAW_FORGE_MAKER_ENTRY=1` TOGETHER when maker-first limit
-  entries land (assune-4yt), so the cost assumption can never silently diverge.
+- **Backtest matches the live executor, both driven by `GCLAW_FORGE_MAKER_ENTRY`**
+  (assune-4yt). Unset (default): `hl_perp.js` opens `isMarket:true` (taker) and the
+  backtest charges taker on both legs = 15bp — identical to today's fills. Set to `1`:
+  the executor posts a resting maker limit (passive to the mark, so it adds liquidity)
+  with the stop STILL atomically attached — a single `hl_create_order` action carrying
+  `price + tpPrice + slPrice + isMarket`, so the entry is NEVER naked — and the backtest
+  charges maker entry. One env var flips both, so the cost model can never diverge from
+  the fill. Builder (`xyz:`) coins always stay taker: their attached SL is not armed as a
+  resting order (assune-ehh), so a resting entry there would fill naked; the executor
+  gates maker off for them.
 - **Scientist prompt biased toward the right setups** (`dna/HEARTBEAT.md` §4b): author
   FEWER, BIGGER, higher-conviction setups that fire rarely and hold long enough that the
   move dwarfs the round trip — not high-frequency scalps that die to fees.

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -95,11 +95,14 @@ HORIZON_BY_TECHNIQUE = {"momentum-stack": 24, "stop-hunt-revert": 4}
 #   taker: 0.045%/side fee + ~3bp slippage into the book/cascade -> ~7.5bp
 TAKER_FEE = 0.00075  # taker fee (4.5bp) + realistic slippage (3bp) per side
 MAKER_FEE = 0.00015  # maker fee (1.5bp), no slippage — you are the resting order
-# Backtest execution mode must MATCH the live executor (hl_perp.js). Today the executor
-# opens with isMarket:true (taker) with an attached TP/SL, so the entry is taker and the
-# TP exit is maker; a stop-hit or time exit is taker. When maker-first limit entries land
-# (assune-4yt), flip GCLAW_FORGE_MAKER_ENTRY=1 in BOTH the backtest and the executor
-# together so the cost assumption never diverges from how fills actually happen.
+# Backtest execution mode must MATCH the live executor (hl_perp.js), and it does: BOTH
+# read GCLAW_FORGE_MAKER_ENTRY. Unset (default) → the executor opens isMarket:true (taker)
+# with an attached TP/SL and the backtest charges taker entry. Set to 1 → the executor
+# posts a resting maker limit with the stop STILL atomically attached (one hl_create_order
+# action, never naked) on the default dex, and the backtest charges maker entry. The single
+# env var keeps the cost assumption from ever diverging from how fills actually happen.
+# Builder (xyz) coins always stay taker: their attached SL is not armed as a resting order
+# (assune-ehh), so a resting entry there would fill naked — hl_perp.js gates maker off for them.
 def _maker_entry() -> bool:
     """True when entries are modelled as resting maker limits (assune-4yt), else taker."""
     return os.environ.get("GCLAW_FORGE_MAKER_ENTRY") == "1"

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -1642,12 +1642,15 @@ def cmd_critique(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _account() -> dict[str, float]:
-    """Read HL equity + free buying power via hl_perp.js (best effort).
+    """Read HL equity + free PERP collateral via hl_perp.js (best effort).
 
-    HL keeps one unified USDC balance; `equity` is the whole account and
-    `buyingPower` is the slice not already pledged as margin. Perp
-    `withdrawable`/`accountValue` only reflect committed margin, so neither is
-    the capital available for a new trade.
+    HL keeps spot and perp as SEPARATE wallets; spot USDC is NOT auto-pledged as
+    perp margin. A new perp draws margin only from the perp wallet's free
+    collateral (`withdrawable`), so that — not the spot `buyingPower` — is what
+    the margin-fit clamp in ``_intent`` must size against. Sizing a perp off spot
+    buying power the perp can't touch yields an intent HL rejects for insufficient
+    margin (assune-4fw.5). ``equity`` stays the whole-account figure for the
+    drawdown breaker and health sizing.
     """
     try:
         proc = subprocess.run(
@@ -1660,7 +1663,7 @@ def _account() -> dict[str, float]:
         equity = float(st.get("equity") or st.get("spotUsdc") or st.get("accountValue") or 0)
         return {
             "equity": equity,
-            "buying_power": float(st.get("buyingPower") or equity),
+            "buying_power": float(st.get("withdrawable") or 0),
             "positions": len(st.get("positions") or []),
         }
     except Exception:
@@ -2213,12 +2216,19 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
     intents.sort(key=lambda x: x["confidence"], reverse=True)
     breaker = circuit_breaker(equity, acct.get("positions", 0))
     veto = _read_json(gclaw_home() / "forge" / "veto.json", {})
+    # Legibility: perp margin (buying_power) below the min-notional requirement means a
+    # sized major zeroes at the margin-fit clamp — the trade can't open even with edge.
+    # Spot USDC is NOT auto-collateral on HL; the gdex backend has no spot->perp
+    # transfer, so surface the underfunding as its own signal rather than letting it
+    # look like "no setup" (assune-4fw.5).
+    perp_underfunded = bool(intents) and (buying_power * 0.95 * cap) < MIN_NOTIONAL
     result = {
         "ok": True,
         "mode": mode,
         "leverage_cap": cap,
         "equity": equity,
         "buying_power": round(buying_power, 2),
+        "perp_underfunded": perp_underfunded,
         "breaker": breaker,
         "veto": bool(veto.get("veto")),
         "intents": intents,

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -44,7 +44,6 @@ from typing import Any
 # proves it can survive. Keep this ladder in sync with hl_perp.js.
 MAX_LEVERAGE = 20  # absolute ceiling at the top of the ladder
 LEVERAGE_LADDER = [(0, 3), (50, 5), (200, 10), (500, 15), (1000, 20)]
-RISK_PCT = {"thrive": 5, "survive": 2, "hibernate": 0}
 MIN_NOTIONAL = 11
 
 # Default markets each adopted technique is scanned across every run: majors on
@@ -1667,6 +1666,40 @@ def _account() -> dict[str, float]:
         return {"equity": 0.0, "buying_power": 0.0, "positions": 0}
 
 
+# The per-trade risk cap is OWNED by riskguard.js (RISK_CAP_PCT) — the deterministic
+# guard that enforces it after the fact. The forge sizes to the SAME number so a
+# freshly-opened position never exceeds the cap the guard would trim it to (assune-met,
+# assune-ir5): one source of truth, read from the owner, never a duplicated constant.
+_RISK_CAP_PCT: float | None = None
+RISK_CAP_FALLBACK_PCT = 1.5  # used only if riskguard.js can't be read this run
+
+
+def risk_cap_pct() -> float:
+    """Per-trade risk cap (% of equity), read once from riskguard.js and cached.
+
+    riskguard.js is the single owner of the cap; ``riskguard.js cap`` prints it as
+    JSON. If that read fails (SDK/node hiccup), fall back to the documented 1.5% so
+    sizing is never LESS strict than the guard — the guard still backstops either way.
+    """
+    global _RISK_CAP_PCT
+    if _RISK_CAP_PCT is not None:
+        return _RISK_CAP_PCT
+    try:
+        proc = subprocess.run(
+            ["node", str(SCRIPT_DIR / "riskguard.js"), "cap"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        data = json.loads(proc.stdout.strip().splitlines()[-1])
+        pct = float(data["risk_cap_pct"])
+        _RISK_CAP_PCT = pct if pct > 0 else RISK_CAP_FALLBACK_PCT
+    except (ValueError, OSError, KeyError, IndexError):
+        _RISK_CAP_PCT = RISK_CAP_FALLBACK_PCT
+    return _RISK_CAP_PCT
+
+
 # Portfolio circuit breaker — halts NEW entries (never closes/blocks risk-reduction)
 # when the account is in trouble, independent of the GMAC life-energy mode.
 MAX_DRAWDOWN_PCT = 25  # halt new entries if equity falls this far below its high-water mark
@@ -1766,10 +1799,12 @@ def _intent(
 ) -> dict[str, Any]:
     """Turn a signal decision into a cap-enforced order intent (cap = earned ceiling).
 
-    Notional AND stop come from ``sizing.py`` (vol-target + sample-shrunk Kelly), not
-    a flat ``RISK_PCT × equity ÷ stop`` fraction: size falls out of the ATR stop and
-    the technique's live regime-matched edge. The buying-power/margin clamp and the
-    $11 min-notional floor are preserved; riskguard.js stays a backstop.
+    Notional AND stop come from ``sizing.py`` (vol-target + sample-shrunk Kelly): size
+    falls out of the ATR stop and the technique's live regime-matched edge. The result
+    is then clamped so the $-at-stop never exceeds the per-trade cap riskguard.js
+    enforces (``risk_cap_pct()`` — one shared source of truth), then to the
+    buying-power/margin ceiling and the $11 min-notional floor. riskguard.js stays a
+    backstop, but a compliant entry never needs trimming (assune-met).
 
     Args:
         tid: The originating technique id.
@@ -1809,10 +1844,24 @@ def _intent(
     # fraction of bankroll, not a veto). Applied to size only, not the entry decision.
     health = _health_size_mult(load_metabolism())
     notional, risk_usd = notional * health, risk_usd * health
+    # Per-trade risk cap (assune-met): the position's $-at-stop must never exceed the
+    # cap riskguard.js enforces. Cap risk HERE, before the order opens, and shrink
+    # notional to match — so the guard never has to trim its own freshly-opened trade
+    # (the churn + orphaned-bracket loss). risk_usd = notional * stop_pct/100, so the
+    # notional that risks exactly the cap is cap_usd / (stop_pct/100). One source of
+    # truth: risk_cap_pct() reads the cap from riskguard.js, never a local copy.
+    risk_cap_usd = equity * (risk_cap_pct() / 100.0)
+    if stop_pct > 0 and risk_usd > risk_cap_usd:
+        # Floor the cap-derived notional to whole cents: the intent reports notional
+        # rounded to 2dp, and rounding UP would let realized risk tip a hair over the
+        # cap. Flooring keeps the opened position strictly at-or-under the cap.
+        notional = math.floor(risk_cap_usd / (stop_pct / 100.0) * 100) / 100
+        risk_usd = notional * (stop_pct / 100.0)
     # Margin = notional / leverage must fit the free collateral (95% headroom for fees).
     max_notional = max(0.0, buying_power * 0.95) * leverage
     if notional > max_notional:
         notional = max_notional
+        risk_usd = notional * (stop_pct / 100.0)  # keep risk honest after the margin clamp
     if notional < MIN_NOTIONAL:
         notional = 0
     return {

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -19,6 +19,10 @@
  *   node hl_perp.js status
  *   node hl_perp.js open  --coin ETH --side long --notional 12 --sl-pct 2 --tp-pct 3
  *   node hl_perp.js close --coin ETH
+ *
+ * Entry fill type follows GCLAW_FORGE_MAKER_ENTRY (assune-4yt): unset → taker market
+ * (default); =1 → resting maker limit with the stop atomically attached, on the default
+ * dex only (builder xyz: coins stay taker — their attached SL is not armed resting).
  */
 'use strict';
 
@@ -184,6 +188,39 @@ function roundSig(value, sig = 5) {
   return Math.round(value * factor) / factor;
 }
 
+// Maker-entry mode (assune-4yt): when GCLAW_FORGE_MAKER_ENTRY=1 the forge models the
+// entry as a resting maker limit, so the live executor must POST one too or the cost
+// model diverges from reality. Only the default dex is eligible: on the xyz builder dex
+// the attached SL trigger is not armed as a resting order (assune-ehh), so a resting
+// entry there would fill naked — builder coins always stay taker.
+function makerEntryEnabled(coin) {
+  return process.env.GCLAW_FORGE_MAKER_ENTRY === '1' && !coin.includes(':');
+}
+
+// A maker limit must rest on the PASSIVE side of the mark so it adds liquidity instead
+// of crossing (which would pay taker): below the mark for a long, above for a short.
+// The offset is small (default 5bp) — wide enough to clear the mark, tight enough to
+// still fill in a normal drift. Returned already rounded to the venue's sig-fig grid.
+function makerLimitPrice(mark, isLong, offsetBps = Number(process.env.GCLAW_MAKER_OFFSET_BPS || 5)) {
+  const off = Math.max(0, offsetBps) / 10000;
+  return roundSig(isLong ? mark * (1 - off) : mark * (1 + off));
+}
+
+// Pure order-param construction — the one place entry price, size, stop, target, and
+// fill type are decided, kept network-free so the maker/taker + atomic-stop contract is
+// unit-testable. In maker mode the entry rests as a passive limit; either way tpPrice
+// AND slPrice are always set (>0), so the emitted order can never be a naked entry.
+function buildOpenOrder({ coin, isLong, mark, notionalTarget, slPct, tpPct, szDecimals }) {
+  const maker = makerEntryEnabled(coin);
+  const entryPx = maker ? makerLimitPrice(mark, isLong) : mark;
+  const size = Math.max(0, Number((notionalTarget / entryPx).toFixed(szDecimals)));
+  const notional = entryPx * size;
+  // Stop/target measured from the ENTRY price so slPct/tpPct hold at whatever price fills.
+  const sl = roundSig(isLong ? entryPx * (1 - slPct / 100) : entryPx * (1 + slPct / 100));
+  const tp = roundSig(isLong ? entryPx * (1 + tpPct / 100) : entryPx * (1 - tpPct / 100));
+  return { maker, entryPx, size, notional, sl, tp, isMarket: !maker };
+}
+
 async function signedSkill(wallet) {
   const { ethers, SDK } = loadSdk();
   const apiKey = process.env.GDEX_API_KEY || SDK.GDEX_API_KEY_PRIMARY;
@@ -309,32 +346,35 @@ async function cmdOpen(wallet, args) {
 
   const px = await markPriceFor(skill, coin);
   const dp = await szDecimalsFor(skill, coin);
-  const size = Math.max(0, Number((notionalTarget / px).toFixed(dp)));
-  const notional = px * size;
+  const { maker, entryPx, size, notional, sl, tp, isMarket } = buildOpenOrder({
+    coin, isLong, mark: px, notionalTarget, slPct, tpPct, szDecimals: dp,
+  });
   if (notional < MIN_NOTIONAL) die(`notional $${notional.toFixed(2)} below $${MIN_NOTIONAL} min — raise --notional`);
 
-  const sl = roundSig(isLong ? px * (1 - slPct / 100) : px * (1 + slPct / 100));
-  const tp = roundSig(isLong ? px * (1 + tpPct / 100) : px * (1 - tpPct / 100));
-  // COST-MODEL CONTRACT: this entry is a TAKER fill (isMarket:true). The forge backtest
-  // charges the matching taker cost by default (forge.py round_trip_cost, with
-  // GCLAW_FORGE_MAKER_ENTRY unset). When maker-first resting-limit entries land
-  // (assune-4yt), flip isMarket:false HERE and set GCLAW_FORGE_MAKER_ENTRY=1 for the forge
-  // TOGETHER — never one without the other, or the graduation cost model diverges from how
-  // fills actually happen and sub-fee noise could graduate.
+  // ATOMICITY / NO NAKED ENTRY: isMarket + price + tpPrice + slPrice are ONE signed
+  // hl_create_order action to ONE endpoint (ABI [coin,isLong,price,size,reduceOnly,
+  // nonce,tpPrice,slPrice,isMarket]). The stop is attached to the entry in the same
+  // request and activates on fill, so a maker resting entry is NEVER naked — there is no
+  // window where the limit rests without its stop. isMarket:false makes it a resting
+  // maker limit (adds liquidity); isMarket:true crosses as taker.
+  //
+  // COST-MODEL CONTRACT: maker mode here MUST move with GCLAW_FORGE_MAKER_ENTRY in the
+  // forge backtest (forge.py round_trip_cost) — both read the same env var, so the
+  // graduation cost model can never diverge from how fills actually happen.
   const res = await skill.hlCreateOrder({
     coin,
     isLong,
-    price: String(px),
+    price: String(entryPx),
     size: String(size),
     reduceOnly: false,
-    isMarket: true,
+    isMarket,
     tpPrice: String(tp),
     slPrice: String(sl),
     leverage,
     ...creds,
   });
   if (res && res.isSuccess === false) die(`open rejected: ${JSON.stringify(res)}`);
-  return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', leverage, leverageCap: cap, mark: px, size, notional: Number(notional.toFixed(2)), sl, tp };
+  return { ok: true, action: 'open', coin, side: isLong ? 'long' : 'short', entryType: maker ? 'maker-limit' : 'taker-market', leverage, leverageCap: cap, mark: px, entryPx, size, notional: Number(notional.toFixed(2)), sl, tp };
 }
 
 // Resolve a position's signed size from the coin's own dex (builder coins live
@@ -450,6 +490,7 @@ async function main() {
 module.exports = {
   computeEquity, mapPositions, normalizeCoin, earnedLeverageCap, roundSig,
   readStatusCache, writeStatusCache, invalidateStatusCache, parseArgs,
+  makerEntryEnabled, makerLimitPrice, buildOpenOrder,
 };
 
 // The HL trader keeps a connection open; exit explicitly so we don't hang.

--- a/scripts/riskguard.js
+++ b/scripts/riskguard.js
@@ -189,6 +189,13 @@ function enforce(dry) {
 
 function main() {
   const cmd = process.argv[2] || 'check';
+  // `cap` exposes the hard caps as JSON so other tools (forge.py sizing) size to the
+  // SAME limits this guard enforces — one source of truth, no duplicated constant.
+  if (cmd === 'cap') {
+    process.stdout.write(JSON.stringify({ ok: true, risk_cap_pct: RISK_CAP_PCT,
+      portfolio_cap_pct: PORTFOLIO_CAP_PCT, tolerance: TOLERANCE, min_notional: MIN_NOTIONAL }) + '\n');
+    return;
+  }
   const out = enforce(cmd !== 'run');
   process.stdout.write(JSON.stringify(out, null, 2) + '\n');
 }

--- a/tests/node/hl_perp.test.js
+++ b/tests/node/hl_perp.test.js
@@ -169,3 +169,85 @@ describe('coin normalization + sig rounding (entry-path helpers)', () => {
     expect(roundSig(0.0123456)).toBeCloseTo(0.012346, 6);
   });
 });
+
+// Maker-first limit entries (assune-4yt): when GCLAW_FORGE_MAKER_ENTRY=1 the live
+// executor must POST a resting maker limit — with the stop STILL atomically attached —
+// so the executor matches the maker cost the forge backtest models. The order builder is
+// network-free, so we drive it directly and assert the maker/taker + no-naked-entry
+// contract. Builder (xyz) coins always stay taker: their attached SL is not armed as a
+// resting order (assune-ehh), so a resting entry there would fill naked.
+describe('maker-first limit entries: order construction (assune-4yt)', () => {
+  const { makerEntryEnabled, makerLimitPrice, buildOpenOrder } = loadScript('hl_perp.js');
+  const savedFlag = process.env.GCLAW_FORGE_MAKER_ENTRY;
+  const savedOff = process.env.GCLAW_MAKER_OFFSET_BPS;
+
+  afterEach(() => {
+    if (savedFlag === undefined) delete process.env.GCLAW_FORGE_MAKER_ENTRY;
+    else process.env.GCLAW_FORGE_MAKER_ENTRY = savedFlag;
+    if (savedOff === undefined) delete process.env.GCLAW_MAKER_OFFSET_BPS;
+    else process.env.GCLAW_MAKER_OFFSET_BPS = savedOff;
+  });
+
+  test('default (flag unset) stays taker: isMarket true, entry at the mark', () => {
+    delete process.env.GCLAW_FORGE_MAKER_ENTRY;
+    expect(makerEntryEnabled('BTC')).toBe(false);
+    const o = buildOpenOrder({ coin: 'BTC', isLong: true, mark: 60000, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 5 });
+    expect(o.isMarket).toBe(true);
+    expect(o.maker).toBe(false);
+    expect(o.entryPx).toBe(60000);
+  });
+
+  test('flag on + default dex: resting maker limit, isMarket false', () => {
+    process.env.GCLAW_FORGE_MAKER_ENTRY = '1';
+    expect(makerEntryEnabled('ETH')).toBe(true);
+    const o = buildOpenOrder({ coin: 'ETH', isLong: true, mark: 3000, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 4 });
+    expect(o.isMarket).toBe(false);
+    expect(o.maker).toBe(true);
+  });
+
+  test('flag on but builder (xyz) coin stays taker — its attached SL is not armed resting', () => {
+    process.env.GCLAW_FORGE_MAKER_ENTRY = '1';
+    expect(makerEntryEnabled('xyz:NVDA')).toBe(false);
+    const o = buildOpenOrder({ coin: 'xyz:NVDA', isLong: true, mark: 120, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 2 });
+    expect(o.isMarket).toBe(true);
+    expect(o.maker).toBe(false);
+  });
+
+  test('a maker limit rests PASSIVE — below the mark for a long, above for a short (never crosses)', () => {
+    process.env.GCLAW_FORGE_MAKER_ENTRY = '1';
+    const long = buildOpenOrder({ coin: 'BTC', isLong: true, mark: 60000, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 5 });
+    expect(long.entryPx).toBeLessThan(60000); // a long that crossed the mark would pay taker
+    const short = buildOpenOrder({ coin: 'BTC', isLong: false, mark: 60000, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 5 });
+    expect(short.entryPx).toBeGreaterThan(60000);
+  });
+
+  test('NEVER a naked entry: the built order always carries a stop AND a target, maker or taker', () => {
+    for (const flag of ['1', '0']) {
+      process.env.GCLAW_FORGE_MAKER_ENTRY = flag;
+      for (const isLong of [true, false]) {
+        const o = buildOpenOrder({ coin: 'SOL', isLong, mark: 140, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 2 });
+        expect(o.sl).toBeGreaterThan(0);
+        expect(o.tp).toBeGreaterThan(0);
+        // stop is on the LOSS side of the entry; target on the profit side.
+        if (isLong) { expect(o.sl).toBeLessThan(o.entryPx); expect(o.tp).toBeGreaterThan(o.entryPx); }
+        else { expect(o.sl).toBeGreaterThan(o.entryPx); expect(o.tp).toBeLessThan(o.entryPx); }
+      }
+    }
+  });
+
+  test('stop/target distance is measured from the ENTRY price, not the mark', () => {
+    process.env.GCLAW_FORGE_MAKER_ENTRY = '1';
+    const o = buildOpenOrder({ coin: 'ETH', isLong: true, mark: 3000, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 4 });
+    // sl is 2% below the resting entry (the fill price), so the risk distance holds on fill.
+    expect(o.sl).toBeCloseTo(o.entryPx * 0.98, 0);
+    expect(o.tp).toBeCloseTo(o.entryPx * 1.03, 0);
+  });
+
+  test('maker offset is configurable and always passive', () => {
+    process.env.GCLAW_MAKER_OFFSET_BPS = '20';
+    const long = makerLimitPrice(60000, true);
+    expect(long).toBeCloseTo(roundSig(60000 * (1 - 20 / 10000)), 5);
+    const short = makerLimitPrice(60000, false);
+    expect(short).toBeGreaterThan(60000);
+  });
+});

--- a/tests/test_forge_perp_margin.py
+++ b/tests/test_forge_perp_margin.py
@@ -1,0 +1,101 @@
+"""Behavior tests for the spot/perp collateral split (assune-4fw.5).
+
+HL keeps spot and perp as SEPARATE wallets; spot USDC is NOT auto-pledged as perp
+margin. ``forge._account`` must therefore report the PERP wallet's free collateral
+(``withdrawable``) as ``buying_power`` — the capital a new perp can actually draw as
+margin — not the spot ``buyingPower``. Sizing a perp off spot buying power the perp
+cannot touch produces an intent HL rejects for insufficient margin.
+
+These tests mock only the ``hl_perp.js status`` subprocess (an external-process
+boundary); the sizing/clamp logic under test runs for real.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import forge  # noqa: E402
+
+
+def _status(**fields: object) -> SimpleNamespace:
+    """A fake CompletedProcess whose stdout is one JSON line, like hl_perp.js status."""
+    return SimpleNamespace(stdout=json.dumps(fields) + "\n", returncode=0)
+
+
+class TestAccountUsesPerpFreeCollateral:
+    """buying_power must be the perp wallet's withdrawable, never the spot balance."""
+
+    def test_all_capital_in_spot_reads_zero_perp_buying_power(self, monkeypatch) -> None:
+        # The live .5 state: $176 in spot, perp fully consumed by a position.
+        monkeypatch.setattr(
+            forge.subprocess,
+            "run",
+            lambda *a, **k: _status(
+                equity=176.0, spotUsdc=176.0, buyingPower=176.0,
+                accountValue=4.0, withdrawable=0.0, positions=[{"coin": "ETH"}],
+            ),
+        )
+        acct = forge._account()
+        assert acct["buying_power"] == 0.0, (
+            "spot USDC was treated as perp margin — a perp sized off it is unfillable"
+        )
+        # equity stays whole-account for the breaker / health sizing.
+        assert acct["equity"] == 176.0
+        assert acct["positions"] == 1
+
+    def test_perp_funded_reads_perp_free_collateral(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            forge.subprocess,
+            "run",
+            lambda *a, **k: _status(
+                equity=200.0, spotUsdc=20.0, buyingPower=20.0,
+                accountValue=180.0, withdrawable=150.0, positions=[],
+            ),
+        )
+        acct = forge._account()
+        assert acct["buying_power"] == 150.0
+        assert acct["equity"] == 200.0
+
+    def test_missing_withdrawable_is_conservative_zero(self, monkeypatch) -> None:
+        # A partial/rate-limited read that omits withdrawable must NOT fall back to
+        # equity (the old bug) — an unknown perp balance is treated as $0 margin.
+        monkeypatch.setattr(
+            forge.subprocess,
+            "run",
+            lambda *a, **k: _status(equity=176.0, spotUsdc=176.0, buyingPower=176.0),
+        )
+        assert forge._account()["buying_power"] == 0.0
+
+
+class TestIntentZeroesWhenPerpUnfunded:
+    """The margin-fit clamp: zero perp collateral => zero notional, regardless of edge."""
+
+    def _decision(self) -> dict[str, object]:
+        return {"action": "long", "stop_pct": 2.0, "confidence": 1.0, "leverage": 3}
+
+    def test_zero_perp_collateral_zeroes_a_valid_major_intent(self, gclaw_home: Path) -> None:
+        intent = forge._intent(
+            "t", "ETH", self._decision(), "thrive",
+            equity=176.0, cap=3, buying_power=0.0,
+            intel={"atr_pct": 1.5, "price": 1600.0},
+            edge={"win_rate": 0.6, "payoff": 1.5, "trades": 40},
+        )
+        assert intent["notional"] == 0, (
+            "a major sized with $0 perp margin must clamp to 0, not a phantom notional"
+        )
+
+    def test_funded_perp_sizes_a_real_major_notional(self, gclaw_home: Path) -> None:
+        intent = forge._intent(
+            "t", "ETH", self._decision(), "thrive",
+            equity=176.0, cap=3, buying_power=150.0,
+            intel={"atr_pct": 1.5, "price": 1600.0},
+            edge={"win_rate": 0.6, "payoff": 1.5, "trades": 40},
+        )
+        assert intent["notional"] == 0 or intent["notional"] >= forge.MIN_NOTIONAL

--- a/tests/test_forge_risk_cap.py
+++ b/tests/test_forge_risk_cap.py
@@ -1,0 +1,151 @@
+"""The forge sizes to the SAME per-trade risk cap riskguard.js enforces (assune-met).
+
+The failure this pins: ``forge.py run --execute`` used to size to full notional, so a
+position could open risking ~4.3% of equity — ~2.85x the 1.5% per-trade cap. riskguard.js
+would then have to TRIM its own freshly-opened trade, churning fees and orphaning brackets.
+
+The fix caps the $-at-stop in ``_intent`` BEFORE the order is built, using the cap read
+from riskguard.js (one source of truth — never a duplicated constant). So:
+
+  * ``risk_cap_pct()`` returns EXACTLY the value riskguard.js exports (RISK_CAP_PCT).
+  * A would-be oversized entry is capped to that % of equity at build time — the notional
+    is shrunk so risk == cap, not left oversized for the guard to trim after the fact.
+  * The cap holds for ANY oversized upstream sizing (property test over the whole space).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import forge  # noqa: E402
+
+_FIXTURE_OK = settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None
+)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated $GCLAW_HOME with a neutral metabolism (health multiplier == 1.0)."""
+    h = tmp_path / ".gclaw"
+    h.mkdir()
+    (h / "metabolism.json").write_text(
+        json.dumps({"mode": "thrive", "goodwill": 0, "seed": 1000, "gmac_balance": 1000}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GCLAW_HOME", str(h))
+    return h
+
+
+@pytest.fixture(autouse=True)
+def _reset_cap_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cap is read once and cached on the module; reset it per test."""
+    monkeypatch.setattr(forge, "_RISK_CAP_PCT", None, raising=False)
+
+
+def _decision(stop_pct: float) -> dict[str, object]:
+    return {"action": "long", "stop_pct": stop_pct, "confidence": 0.9, "leverage": 3}
+
+
+def _riskguard_cap_pct() -> float:
+    """The cap as riskguard.js itself reports it — the authority forge must match."""
+    out = subprocess.run(
+        ["node", str(SCRIPTS_DIR / "riskguard.js"), "cap"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return float(json.loads(out.stdout.strip().splitlines()[-1])["risk_cap_pct"])
+
+
+def test_forge_reads_the_same_cap_riskguard_enforces() -> None:
+    """One source of truth: forge's cap is exactly the number riskguard.js owns."""
+    assert forge.risk_cap_pct() == pytest.approx(_riskguard_cap_pct())
+
+
+def test_oversized_entry_is_capped_before_it_opens(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A would-be 4.3%-risk entry (the assune-met repro) is capped to 1.5% AT BUILD TIME.
+
+    We force the brain to return the over-sized position the old flat-notional path would
+    (SOL long, ~$543 notional on $190.50 equity, ~4.3% at the stop) and assert ``_intent``
+    shrinks it so the entry opens already at the cap — riskguard never has to trim it.
+    """
+    equity = 190.50
+    stop_pct = 4.75  # ATR stop distance, %
+    oversized_notional = 543.0
+    oversized_risk = oversized_notional * stop_pct / 100.0  # ~= $25.79, ~13.5% of equity
+
+    def fake_brain(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "notional_usd": oversized_notional,
+            "stop_distance_pct": stop_pct,
+            "risk_usd": oversized_risk,
+        }
+
+    monkeypatch.setattr(forge, "_size_via_brain", fake_brain)
+    intent = forge._intent(
+        "t", "SOL", _decision(stop_pct), "thrive", equity, cap=3, buying_power=equity
+    )
+
+    cap_pct = forge.risk_cap_pct()
+    cap_usd = equity * cap_pct / 100.0
+    # The REAL position is intent["notional"] (reported cents); its $-at-stop must be
+    # at or under the cap — capped before open, not trimmed after. No fudge factor: the
+    # notional is floored to cents so realized risk never tips over the cap.
+    realized = intent["notional"] * stop_pct / 100.0
+    assert realized <= cap_usd, (
+        f"entry risks ${realized:.4f} > ${cap_usd:.4f} cap ({cap_pct}% of ${equity})"
+    )
+    # It was shrunk to sit right at the cap (within one cent of notional rounding).
+    assert realized == pytest.approx(cap_usd, abs=stop_pct / 100.0 * 0.01)
+    # It really is smaller than the oversized input — the cap bound, not the margin clamp.
+    assert intent["notional"] < oversized_notional
+
+
+@_FIXTURE_OK
+@given(
+    equity=st.floats(min_value=50.0, max_value=1e6, allow_nan=False),
+    stop_pct=st.floats(min_value=0.5, max_value=25.0, allow_nan=False),
+    over_mult=st.floats(min_value=1.01, max_value=50.0, allow_nan=False),
+)
+def test_capped_for_any_oversized_sizing(
+    home: Path, monkeypatch: pytest.MonkeyPatch, equity: float, stop_pct: float, over_mult: float
+) -> None:
+    """For ANY oversized brain output, the built entry risks <= the riskguard cap.
+
+    buying_power is set huge so the margin clamp never binds — this isolates the
+    per-trade RISK cap as the thing that must hold.
+    """
+    cap_usd = equity * forge.risk_cap_pct() / 100.0
+    # A notional whose $-at-stop is `over_mult` times the cap — always over-cap.
+    notional = (cap_usd * over_mult) / (stop_pct / 100.0)
+
+    def fake_brain(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "notional_usd": notional,
+            "stop_distance_pct": stop_pct,
+            "risk_usd": notional * stop_pct / 100.0,
+        }
+
+    monkeypatch.setattr(forge, "_size_via_brain", fake_brain)
+    intent = forge._intent(
+        "t", "BTC", _decision(stop_pct), "thrive", equity, cap=20, buying_power=1e12
+    )
+    if intent["notional"] == 0:
+        return  # sub-min-notional entries are dropped, which is also compliant
+    realized = intent["notional"] * stop_pct / 100.0
+    assert realized <= cap_usd, f"realized ${realized} over ${cap_usd} cap"


### PR DESCRIPTION
Closes the real gaps behind the un-stick epic (assune-4fw), so the organism trades proven edge safely and honestly.

**Perp-collateral sizing (assune-4fw.5).** forge.py sized off the $176 SPOT balance, but HL perps need PERP-account margin (spot isn't collateral) — so the armed executor could fire an unfillable order. Now `_account` sizes off perp free collateral (`withdrawable`); a `perp_underfunded` flag makes the shortfall legible. Follow-up assune-76z tracks actually funding the perp wallet (external deposit / gdex usdClassTransfer) — the wallet here can't locally sign the transfer HL would accept.

**Riskguard cap at build time (assune-met).** forge.py `_intent` now clamps $-at-stop to the per-trade cap BEFORE the order opens, with ONE source of truth (riskguard.js owns RISK_CAP_PCT, exposed via a `cap` subcommand; forge reads it, falls back to 1.5%). The guard becomes a pure backstop instead of trimming its own fresh trade. Dead `RISK_PCT` constant removed.

**Maker-first entries (assune-4yt).** Verified the SDK submits entry + TP/SL as ONE signed action (no naked window). hl_perp.js `open` honors GCLAW_FORGE_MAKER_ENTRY: default taker; =1 posts a resting maker limit passive to the mark with the stop atomically attached. Builder (xyz:) coins forced taker (their attached stop isn't a resting order). Backtest + executor now flip together on one flag.

Both _intent clamps compose (risk-cap ∧ margin-fit). A live ETH probe is open + stop-protected throughout. ruff/node/vitest(301)/pytest all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)