### PR TITLE
Fix: size perps off free spot collateral (account is cross-collateral)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -75,15 +75,13 @@ Run this whenever the user invokes the skill or the scheduled loop fires.
    `uv run --no-project python3 scripts/telepathy.py inbox` (act on fresh trade_signal/warning).
    Read live exposure via `mcp__gdex__get_hl_clearinghouse_state {userAddress: <managed>}`,
    `get_hl_spot_state`, and `get_hl_open_orders` — the source of truth for positions and free capital.
-   **Capital gauge:** HL keeps spot and perp as SEPARATE wallets. `node scripts/hl_perp.js
-   status` reports both: `buyingPower` (spot USDC `total − hold`) and `withdrawable` (free
-   PERP collateral). Spot USDC is NOT auto-pledged as perp margin — a new perp draws margin
-   ONLY from the perp wallet, so its capacity is `withdrawable`, not `buyingPower`. If perp
-   `withdrawable` is ~$0 while spot holds the balance, no perp can open until the perp wallet
-   is funded. The gdex backend has NO spot→perp transfer (`hl_deposit` bridges external
-   Arbitrum USDC into perp; `hl_swap_collateral` swaps dex tokens) and gclaw cannot sign an
-   HL `usdClassTransfer` locally (funds sit under the managed account, whose key it does not
-   hold), so perp funding needs an external deposit or gdex backend support (assune-4fw.5).
+   **Capital gauge:** this HL account is CROSS-COLLATERAL — a perp draws its margin from the
+   spot USDC pool (the margin shows as a spot `hold` AND inside the perp `accountValue`).
+   `node scripts/hl_perp.js status` computes `buyingPower` = spot USDC `total − hold` = the
+   FREE collateral a new perp can actually draw. Size perps off `buyingPower`, NOT the
+   perp-only `withdrawable` (which reads ~$0 whenever margin is deployed even though ample
+   spot backs it — sizing off it wrongly starves every major to $0 notional). `equity`
+   (`buyingPower + accountValue`) is the whole-account figure for the drawdown breaker.
 4. **Reconcile closes (auto).** Run `node scripts/autosettle.js run` — it books realized PnL from any
    closes (TP/SL or manual) by reading HL fills, netting `closedPnl − fee`, and calling `metabolism.py
    settle` exactly once per close (cursor-deduped; safe if the cron already ran it). Don't settle trade

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -1644,14 +1644,16 @@ def cmd_critique(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _account() -> dict[str, float]:
-    """Read HL equity + free PERP collateral via hl_perp.js (best effort).
+    """Read HL equity + free trading collateral via hl_perp.js (best effort).
 
-    HL keeps spot and perp as SEPARATE wallets; spot USDC is NOT auto-pledged as
-    perp margin. A new perp draws margin only from the perp wallet's free
-    collateral (`withdrawable`), so that — not the spot `buyingPower` — is what
-    the margin-fit clamp in ``_intent`` must size against. Sizing a perp off spot
-    buying power the perp can't touch yields an intent HL rejects for insufficient
-    margin (assune-4fw.5). ``equity`` stays the whole-account figure for the
+    This HL account is CROSS-COLLATERAL: a perp position draws its margin from the
+    spot USDC pool — the margin shows up as a spot ``hold`` AND inside the perp
+    ``accountValue`` (hl_perp.js's two-wallet equity formula). So the collateral a
+    new perp can actually draw is the FREE spot USDC (``buyingPower`` = spot total −
+    hold), NOT the perp-only ``withdrawable`` (which reads $0 whenever margin is
+    deployed even though ample spot backs it). Sizing off ``withdrawable`` starved
+    every major to $0 notional; ``buyingPower`` is what the margin-fit clamp in
+    ``_intent`` must size against. ``equity`` stays the whole-account figure for the
     drawdown breaker and health sizing.
     """
     try:
@@ -1665,7 +1667,7 @@ def _account() -> dict[str, float]:
         equity = float(st.get("equity") or st.get("spotUsdc") or st.get("accountValue") or 0)
         return {
             "equity": equity,
-            "buying_power": float(st.get("withdrawable") or 0),
+            "buying_power": float(st.get("buyingPower") or 0),
             "positions": len(st.get("positions") or []),
         }
     except Exception:
@@ -2268,11 +2270,10 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
     intents.sort(key=lambda x: x["confidence"], reverse=True)
     breaker = circuit_breaker(equity, acct.get("positions", 0))
     veto = _read_json(gclaw_home() / "forge" / "veto.json", {})
-    # Legibility: perp margin (buying_power) below the min-notional requirement means a
-    # sized major zeroes at the margin-fit clamp — the trade can't open even with edge.
-    # Spot USDC is NOT auto-collateral on HL; the gdex backend has no spot->perp
-    # transfer, so surface the underfunding as its own signal rather than letting it
-    # look like "no setup" (assune-4fw.5).
+    # Legibility: free collateral (buying_power = free spot USDC, the cross-collateral a
+    # perp draws margin from) below the min-notional requirement means a sized major zeroes
+    # at the margin-fit clamp — the trade can't open even with edge. Surface that as its own
+    # signal rather than letting it look like "no setup" (assune-4fw.5).
     perp_underfunded = bool(intents) and (buying_power * 0.95 * cap) < MIN_NOTIONAL
     result = {
         "ok": True,

--- a/tests/test_forge_perp_margin.py
+++ b/tests/test_forge_perp_margin.py
@@ -1,10 +1,13 @@
-"""Behavior tests for the spot/perp collateral split (assune-4fw.5).
+"""Behavior tests for forge perp sizing against the cross-collateral pool (assune-4fw.5).
 
-HL keeps spot and perp as SEPARATE wallets; spot USDC is NOT auto-pledged as perp
-margin. ``forge._account`` must therefore report the PERP wallet's free collateral
-(``withdrawable``) as ``buying_power`` — the capital a new perp can actually draw as
-margin — not the spot ``buyingPower``. Sizing a perp off spot buying power the perp
-cannot touch produces an intent HL rejects for insufficient margin.
+This HL account is CROSS-COLLATERAL: a perp draws its margin from the spot USDC pool
+(the margin shows as a spot ``hold`` AND inside the perp ``accountValue`` — hl_perp.js's
+two-wallet equity formula). So ``forge._account`` must report the FREE spot USDC
+(``buyingPower`` = spot total − hold) as ``buying_power`` — the capital a new perp can
+actually draw — NOT the perp-only ``withdrawable`` (which reads $0 whenever margin is
+deployed even though ample spot backs it). Sizing off ``withdrawable`` starved every
+major to $0 notional; sizing off ``buyingPower`` is correct and is what let a live probe
+open.
 
 These tests mock only the ``hl_perp.js status`` subprocess (an external-process
 boundary); the sizing/clamp logic under test runs for real.
@@ -29,58 +32,61 @@ def _status(**fields: object) -> SimpleNamespace:
     return SimpleNamespace(stdout=json.dumps(fields) + "\n", returncode=0)
 
 
-class TestAccountUsesPerpFreeCollateral:
-    """buying_power must be the perp wallet's withdrawable, never the spot balance."""
+class TestAccountUsesFreeSpotCollateral:
+    """buying_power must be the FREE spot USDC (buyingPower), the cross-collateral pool."""
 
-    def test_all_capital_in_spot_reads_zero_perp_buying_power(self, monkeypatch) -> None:
-        # The live .5 state: $176 in spot, perp fully consumed by a position.
+    def test_capital_in_spot_is_usable_perp_collateral(self, monkeypatch) -> None:
+        # The live state: $176 in spot backing a small perp position (perp margin is
+        # drawn from spot). withdrawable reads $0 while margin is deployed, but the
+        # ~$172 free spot IS the collateral a new perp can draw.
         monkeypatch.setattr(
             forge.subprocess,
             "run",
             lambda *a, **k: _status(
-                equity=176.0, spotUsdc=176.0, buyingPower=176.0,
+                equity=176.0, spotUsdc=176.0, buyingPower=172.0,
                 accountValue=4.0, withdrawable=0.0, positions=[{"coin": "ETH"}],
             ),
         )
         acct = forge._account()
-        assert acct["buying_power"] == 0.0, (
-            "spot USDC was treated as perp margin — a perp sized off it is unfillable"
+        assert acct["buying_power"] == 172.0, (
+            "free spot USDC (buyingPower) is the cross-collateral a perp draws margin from; "
+            "sizing off withdrawable=$0 wrongly starves every major to $0 notional"
         )
-        # equity stays whole-account for the breaker / health sizing.
         assert acct["equity"] == 176.0
         assert acct["positions"] == 1
 
-    def test_perp_funded_reads_perp_free_collateral(self, monkeypatch) -> None:
+    def test_buying_power_tracks_free_spot_after_hold(self, monkeypatch) -> None:
+        # hl_perp.js already nets the margin hold out of buyingPower; forge just uses it.
         monkeypatch.setattr(
             forge.subprocess,
             "run",
             lambda *a, **k: _status(
-                equity=200.0, spotUsdc=20.0, buyingPower=20.0,
-                accountValue=180.0, withdrawable=150.0, positions=[],
+                equity=200.0, spotUsdc=200.0, buyingPower=20.0,
+                accountValue=180.0, withdrawable=0.0, positions=[{"coin": "BTC"}],
             ),
         )
         acct = forge._account()
-        assert acct["buying_power"] == 150.0
+        assert acct["buying_power"] == 20.0
         assert acct["equity"] == 200.0
 
-    def test_missing_withdrawable_is_conservative_zero(self, monkeypatch) -> None:
-        # A partial/rate-limited read that omits withdrawable must NOT fall back to
-        # equity (the old bug) — an unknown perp balance is treated as $0 margin.
+    def test_missing_buying_power_is_conservative_zero(self, monkeypatch) -> None:
+        # A partial/rate-limited read that omits buyingPower must NOT fall back to equity
+        # (the old bug) — an unknown free balance is treated as $0 tradeable collateral.
         monkeypatch.setattr(
             forge.subprocess,
             "run",
-            lambda *a, **k: _status(equity=176.0, spotUsdc=176.0, buyingPower=176.0),
+            lambda *a, **k: _status(equity=176.0, spotUsdc=176.0, accountValue=4.0),
         )
         assert forge._account()["buying_power"] == 0.0
 
 
-class TestIntentZeroesWhenPerpUnfunded:
-    """The margin-fit clamp: zero perp collateral => zero notional, regardless of edge."""
+class TestIntentSizesAgainstBuyingPower:
+    """The margin-fit clamp: zero collateral => zero notional; funded => a real notional."""
 
     def _decision(self) -> dict[str, object]:
         return {"action": "long", "stop_pct": 2.0, "confidence": 1.0, "leverage": 3}
 
-    def test_zero_perp_collateral_zeroes_a_valid_major_intent(self, gclaw_home: Path) -> None:
+    def test_zero_collateral_zeroes_a_valid_major_intent(self, gclaw_home: Path) -> None:
         intent = forge._intent(
             "t", "ETH", self._decision(), "thrive",
             equity=176.0, cap=3, buying_power=0.0,
@@ -88,14 +94,16 @@ class TestIntentZeroesWhenPerpUnfunded:
             edge={"win_rate": 0.6, "payoff": 1.5, "trades": 40},
         )
         assert intent["notional"] == 0, (
-            "a major sized with $0 perp margin must clamp to 0, not a phantom notional"
+            "a major sized with $0 free collateral must clamp to 0, not a phantom notional"
         )
 
-    def test_funded_perp_sizes_a_real_major_notional(self, gclaw_home: Path) -> None:
+    def test_funded_collateral_sizes_a_real_major_notional(self, gclaw_home: Path) -> None:
         intent = forge._intent(
             "t", "ETH", self._decision(), "thrive",
             equity=176.0, cap=3, buying_power=150.0,
             intel={"atr_pct": 1.5, "price": 1600.0},
             edge={"win_rate": 0.6, "payoff": 1.5, "trades": 40},
         )
-        assert intent["notional"] == 0 or intent["notional"] >= forge.MIN_NOTIONAL
+        assert intent["notional"] >= forge.MIN_NOTIONAL, (
+            "with ample cross-collateral a proven major must size to a real, fillable notional"
+        )


### PR DESCRIPTION
Corrects the perp-sizing regression from #116. This HL account is cross-collateral — perp margin is drawn from the spot USDC pool (the position margin shows as a spot `hold` AND in perp `accountValue`; hl_perp.js computes `buyingPower = spot total − hold` as the free tradeable collateral). #116 wrongly sized off the perp-only `withdrawable` (=$0 with margin deployed), starving every major to $0. Now sizes off `buyingPower`. No spot→perp transfer is needed — the $176 spot already backs perps. Verified: BTC sizes to $25.98, perp_underfunded=False; full pytest + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)