### PR TITLE
Fix CI: install ruff/ethers, tolerate absent SDK, format the tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: ci
 
 # Unit tests + lint for the Gclaw skill. Fast (<1 min): pure-logic tests, no
-# network, no real clock, no real $GCLAW_HOME. The node scripts' runtime deps
-# (ethers, the GDEX SDK) are NOT installed — only vitest — because the tested
-# functions are pure and never reach the SDK boundary.
+# network, no real clock, no real $GCLAW_HOME. vitest + ethers are installed
+# (predict.js's tested keccak path needs ethers); the GDEX SDK is NOT — scripts
+# that need it load it tolerantly, and their tested functions are pure.
 
 on:
   push:
@@ -30,8 +30,8 @@ jobs:
           enable-cache: true
       - name: Lint (ruff)
         run: |
-          uv run --no-project ruff format --check scripts tests
-          uv run --no-project ruff check scripts tests
+          uvx ruff@0.15.13 format --check scripts tests
+          uvx ruff@0.15.13 check scripts tests
       - name: Test (pytest)
         run: uv run --group dev pytest
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,23 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "0.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gclaw-skill-tests",
-      "version": "0.0.0",
+      "version": "4.0.0",
       "devDependencies": {
+        "ethers": "6.16.0",
         "vitest": "4.1.9"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -69,6 +77,32 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -388,6 +422,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -501,6 +547,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -554,6 +607,59 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -1075,6 +1181,15 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/vite": {
       "version": "8.0.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
@@ -1258,6 +1373,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "gclaw-skill-tests",
   "version": "4.0.0",
   "private": true,
-  "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime; only vitest is installed here.",
+  "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not — scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "ethers": "6.16.0",
     "vitest": "4.1.9"
   }
 }

--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -55,9 +55,12 @@ def gather() -> dict:
         # status cache can still report a position that closed within the window (a phantom).
         # This also refreshes the cache for cheaper downstream consumers.
         "account": _run_json(["node", str(scripts / "hl_perp.js"), "status"], {}),
-        "forge": _run_json(["uv", "run", "--no-project", "python3", str(scripts / "forge.py"), "run"], {}),
+        "forge": _run_json(
+            ["uv", "run", "--no-project", "python3", str(scripts / "forge.py"), "run"], {}
+        ),
         "economics": _run_json(
-            ["uv", "run", "--no-project", "python3", str(scripts / "audit_economics.py"), "report"], {}
+            ["uv", "run", "--no-project", "python3", str(scripts / "audit_economics.py"), "report"],
+            {},
         ),
         # Scientist board: the adopted loadout (each entry carries weight/e/trades) and
         # the learned per-(technique, regime) edge — the raw material for authoring.
@@ -69,7 +72,8 @@ def gather() -> dict:
             ["uv", "run", "--no-project", "python3", str(scripts / "outcomes.py"), "markets"], {}
         ),
         "calibration": _run_json(
-            ["uv", "run", "--no-project", "python3", str(scripts / "outcomes.py"), "calibration"], {}
+            ["uv", "run", "--no-project", "python3", str(scripts / "outcomes.py"), "calibration"],
+            {},
         ),
     }
 
@@ -158,7 +162,10 @@ def render_briefing(d: dict) -> str:
     orders = acct.get("openOrders") or []
     allow = breaker.get("allow_entry", not breaker.get("tripped", False))
 
-    out = ["## Cycle briefing — PRE-GATHERED (do not re-fetch positions, market data, or run the forge)", ""]
+    out = [
+        "## Cycle briefing — PRE-GATHERED (do not re-fetch positions, market data, or run the forge)",
+        "",
+    ]
     out.append(
         f"**Survival:** mode {mode} · GMAC {_f(meta.get('gmac_balance')):.0f}/"
         f"{_f(meta.get('seed'), 1000):.0f} · goodwill {meta.get('goodwill', 0)} · "
@@ -170,11 +177,15 @@ def render_briefing(d: dict) -> str:
             f"{abs(_f(p.get('size')))}@{_money(p.get('entryPx'))} (uPnL {_money(p.get('unrealizedPnl'))})"
             for p in positions
         )
-        out.append(f"**Account:** equity {_money(equity)} · buying power {_money(bp)} · "
-                   f"{len(positions)} OPEN — {pos} · {len(orders)} resting orders")
+        out.append(
+            f"**Account:** equity {_money(equity)} · buying power {_money(bp)} · "
+            f"{len(positions)} OPEN — {pos} · {len(orders)} resting orders"
+        )
     else:
-        out.append(f"**Account:** equity {_money(equity)} · buying power {_money(bp)} · "
-                   f"**flat (0 open positions)** · {len(orders)} resting orders")
+        out.append(
+            f"**Account:** equity {_money(equity)} · buying power {_money(bp)} · "
+            f"**flat (0 open positions)** · {len(orders)} resting orders"
+        )
     dd = breaker.get("drawdown_pct", breaker.get("drawdown", "?"))
     out.append(
         f"**Risk gate:** circuit breaker {'CLEAR — entries allowed' if allow else 'TRIPPED — no new entries'} "
@@ -183,7 +194,9 @@ def render_briefing(d: dict) -> str:
     live = sorted((c, f) for c, f in intel.items() if f and f.get("regime") != "chop")
     chop = sorted(c for c, f in intel.items() if f and f.get("regime") == "chop")
     if live:
-        names = " · ".join(f"{c} {f.get('regime')}{'✓' if f.get('tradeable') else ''}" for c, f in live)
+        names = " · ".join(
+            f"{c} {f.get('regime')}{'✓' if f.get('tradeable') else ''}" for c, f in live
+        )
         out.append(f"**Tradeable now ({len(live)}):** {names}")
     else:
         out.append("**Tradeable now:** none — whole board is chop")
@@ -194,7 +207,9 @@ def render_briefing(d: dict) -> str:
         out.append("**Forge intents (ranked by confidence):**")
         for it in intents[:6]:
             tag = "✅ PROVEN (executable)" if it.get("proven") else "— unproven (explore only)"
-            out.append(f"  {it.get('coin')} {it.get('side')} conf {it.get('confidence')} {tag} [{it.get('technique')}]")
+            out.append(
+                f"  {it.get('coin')} {it.get('side')} conf {it.get('confidence')} {tag} [{it.get('technique')}]"
+            )
     else:
         out.append("**Forge intents:** none — no technique cleared on any market this scan")
     if econ.get("n"):
@@ -234,7 +249,9 @@ def _scientist_board(style: dict, regime_stats: dict, intel: dict) -> list[str]:
     else:
         lines.append("  (none adopted)")
     # Which live (non-chop) regimes have NO technique with positive learned edge → gaps to invent for.
-    live_regimes = {f.get("regime") for f in intel.values() if f and f.get("regime") not in (None, "chop")}
+    live_regimes = {
+        f.get("regime") for f in intel.values() if f and f.get("regime") not in (None, "chop")
+    }
     covered = {
         rg for stats in regime_stats.values() for rg, s in stats.items() if _f(s.get("e")) > 0
     }
@@ -267,8 +284,13 @@ def _event_desk_board(outcomes: dict, calibration: dict, intel: dict) -> list[st
     for s in sides:
         m = by_market.setdefault(
             s.get("outcomeId"),
-            {"name": s.get("name"), "sides": [], "vol": 0.0,
-             "resolution": _resolution_label(s), "ref_side": s},
+            {
+                "name": s.get("name"),
+                "sides": [],
+                "vol": 0.0,
+                "resolution": _resolution_label(s),
+                "ref_side": s,
+            },
         )
         m["sides"].append(s)
         m["vol"] += _f(s.get("volumeUsd"))
@@ -286,7 +308,9 @@ def _event_desk_board(outcomes: dict, calibration: dict, intel: dict) -> list[st
     else:
         lines.append("  (no markets clear the volume floor)")
     if not edgeable and outcomes.get("no_edgeable_market"):
-        lines.append(f"  ↳ NO EDGEABLE MARKET: {outcomes['no_edgeable_market']} — desk idle by design")
+        lines.append(
+            f"  ↳ NO EDGEABLE MARKET: {outcomes['no_edgeable_market']} — desk idle by design"
+        )
     open_t = calibration.get("open") or []
     if open_t:
         held = "; ".join(
@@ -300,7 +324,11 @@ def _event_desk_board(outcomes: dict, calibration: dict, intel: dict) -> list[st
     agg = calibration.get("aggregates") or {}
     brier, baseline = agg.get("brier_mean"), agg.get("baseline_mean")
     if agg.get("n_resolved"):
-        verdict = "BEATING no-skill" if brier is not None and baseline is not None and brier < baseline else "below no-skill baseline"
+        verdict = (
+            "BEATING no-skill"
+            if brier is not None and baseline is not None and brier < baseline
+            else "below no-skill baseline"
+        )
         lines.append(
             f"**Calibration:** {agg.get('n')} tickets ({agg.get('n_shadow')} shadow / "
             f"{agg.get('n_live')} live) · {agg.get('n_resolved')} resolved · "

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -182,7 +182,11 @@ def breed(
     species, sigil = parent["species"], parent["sigil"]
     prefix_i = next((i for i, p in enumerate(SPECIES_PREFIX) if species.startswith(p)), 0)
     suffix_i = next(
-        (j for j, sfx in enumerate(SPECIES_SUFFIX) if sfx == species[len(SPECIES_PREFIX[prefix_i]) :]),
+        (
+            j
+            for j, sfx in enumerate(SPECIES_SUFFIX)
+            if sfx == species[len(SPECIES_PREFIX[prefix_i]) :]
+        ),
         0,
     )
     sigil_i = SIGILS.index(sigil) if sigil in SIGILS else 0
@@ -316,9 +320,9 @@ def banner_datauri() -> str:
         return _BANNER_CACHE
     img = SCRIPT_DIR.parent / "assets" / "brand" / "dashboard-banner.jpg"
     try:
-        _BANNER_CACHE = "data:image/jpeg;base64," + base64.b64encode(
-            img.read_bytes()
-        ).decode("ascii")
+        _BANNER_CACHE = "data:image/jpeg;base64," + base64.b64encode(img.read_bytes()).decode(
+            "ascii"
+        )
     except (OSError, ValueError):
         _BANNER_CACHE = ""
     return _BANNER_CACHE
@@ -431,9 +435,21 @@ def refresh_qr(h: Path) -> None:
             continue
         try:
             subprocess.run(
-                ["uv", "run", "--no-project", "--with", "qrcode", "python3",
-                 str(SCRIPT_DIR / "qr.py"), addr, chain, str(out)],
-                capture_output=True, text=True, timeout=60,
+                [
+                    "uv",
+                    "run",
+                    "--no-project",
+                    "--with",
+                    "qrcode",
+                    "python3",
+                    str(SCRIPT_DIR / "qr.py"),
+                    addr,
+                    chain,
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
         except (OSError, subprocess.SubprocessError):
             pass
@@ -445,9 +461,23 @@ def github_qr_datauri(h: Path) -> str:
     if not (png.exists() and png.stat().st_size > 0):
         try:
             subprocess.run(
-                ["uv", "run", "--no-project", "--with", "qrcode", "--with", "pillow",
-                 "python3", str(SCRIPT_DIR / "qr.py"), GITHUB_URL, "raw", str(png)],
-                capture_output=True, text=True, timeout=120,
+                [
+                    "uv",
+                    "run",
+                    "--no-project",
+                    "--with",
+                    "qrcode",
+                    "--with",
+                    "pillow",
+                    "python3",
+                    str(SCRIPT_DIR / "qr.py"),
+                    GITHUB_URL,
+                    "raw",
+                    str(png),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
         except (OSError, subprocess.SubprocessError):
             return ""
@@ -514,7 +544,9 @@ def refresh(h: Path, live: bool = True) -> dict[str, Any]:
         "style": style,
         "proven_markets": load_json(h / "forge" / "proven_markets.json", {}).get("pairs", []),
         "techniques": _load_techniques(h, style.get("adopted", [])),
-        "authored_cards": _load_authored(h, (metabolism.get("onchain_identity") or {}).get("agentId", "")),
+        "authored_cards": _load_authored(
+            h, (metabolism.get("onchain_identity") or {}).get("agentId", "")
+        ),
         "journal": read_jsonl(h / "journal.jsonl"),
         "telepathy": read_jsonl(h / "telepathy" / "bus.jsonl"),
         "positions": load_json(h / "positions.json", {}),
@@ -712,20 +744,20 @@ def hero_html(state: dict[str, Any], proven: list[dict[str, Any]], gate: dict[st
     n = len(proven)
     born_count = int((state["reputation"].get("evolution") or {}).get("proven_edge_count", n) or n)
     delta = el("span", esc(f"+{born_count} since birth"), cls="herodelta") if born_count else ""
-    ribbon = (
-        el("span", "⚡ BREED-READY", cls="ribbon", id="breedRibbon")
-        if gate["ready"]
-        else ""
-    )
+    ribbon = el("span", "⚡ BREED-READY", cls="ribbon", id="breedRibbon") if gate["ready"] else ""
     # The self-evolving-DNA hero art sits behind the number, aligned right (its subject),
     # under a left-heavy rich-black scrim so the PROVEN EDGE count stays razor-crisp.
     bg = state.get("hero_bg") or ""
     style = (
-        "background:linear-gradient(90deg,rgba(6,10,23,.97) 0%,rgba(6,10,23,.82) 38%,"
-        f"rgba(6,10,23,.32) 72%,rgba(6,10,23,.6) 100%),url({bg}) center right/cover no-repeat;"
-        "border:1px solid var(--line);padding:34px 30px;min-height:220px;"
-        "display:flex;flex-direction:column;justify-content:center"
-    ) if bg else ""
+        (
+            "background:linear-gradient(90deg,rgba(6,10,23,.97) 0%,rgba(6,10,23,.82) 38%,"
+            f"rgba(6,10,23,.32) 72%,rgba(6,10,23,.6) 100%),url({bg}) center right/cover no-repeat;"
+            "border:1px solid var(--line);padding:34px 30px;min-height:220px;"
+            "display:flex;flex-direction:column;justify-content:center"
+        )
+        if bg
+        else ""
+    )
     attrs = {"style": style} if style else {}
     return el(
         "section",
@@ -733,7 +765,13 @@ def hero_html(state: dict[str, Any], proven: list[dict[str, Any]], gate: dict[st
         el(
             "div",
             el("span", esc(str(n)), cls="heronum", id="provenEdge"),
-            el("div", el("div", "techniques graduated", cls="herolabel"), delta, ribbon, cls="herometa"),
+            el(
+                "div",
+                el("div", "techniques graduated", cls="herolabel"),
+                delta,
+                ribbon,
+                cls="herometa",
+            ),
             cls="herorow",
         ),
         el("div", "forge-proven · out-of-sample · inheritable", cls="herosub"),
@@ -768,7 +806,11 @@ def vitals_html(state: dict[str, Any], gate: dict[str, Any]) -> str:
 
     return el(
         "div",
-        vital("Self-authored", str(authored), f"{int(state['metabolism'].get('recodes', 0) or 0)} recodes"),
+        vital(
+            "Self-authored",
+            str(authored),
+            f"{int(state['metabolism'].get('recodes', 0) or 0)} recodes",
+        ),
         vital("Event calibration", cal_val, cal_sub),
         vital("Breed-ready", breed_val, breed_sub, em=gate["ready"]),
         cls="vitals",
@@ -791,7 +833,14 @@ def track_record_html(state: dict[str, Any]) -> str:
         body = (
             el("b", esc(_fmt_money(rec["pnl"])), cls="trpnl")
             + esc(f" · {rec['closes']} closes · {rec['win_rate'] * 100:.0f}% win · ")
-            + el("a", "re-derivable onchain ↗", cls="trlink", href=verify, target="_blank", rel="noopener")
+            + el(
+                "a",
+                "re-derivable onchain ↗",
+                cls="trlink",
+                href=verify,
+                target="_blank",
+                rel="noopener",
+            )
         )
     return el(
         "div",
@@ -911,14 +960,20 @@ def calibration_html(state: dict[str, Any]) -> str:
             x = 10 + float(b.get("p", 0)) * 120
             y = 130 - float(b.get("obs", 0)) * 120
             pts.append(f"{x:.1f},{y:.1f}")
-        curve = f'<polyline points="{" ".join(pts)}" fill="none" stroke="#49B875" stroke-width="2"/>'
+        curve = (
+            f'<polyline points="{" ".join(pts)}" fill="none" stroke="#49B875" stroke-width="2"/>'
+        )
     svg = (
         '<svg viewBox="0 0 140 140" width="140" height="140" class="calsvg">'
         '<rect x="10" y="10" width="120" height="120" fill="none" stroke="#1e2c49"/>'
         f"{diag}{curve}</svg>"
     )
     if n == 0:
-        note = el("p", "n=0 — the mind hasn't yet learned to doubt itself. Brier appears after the first calibrated event forecasts.", cls="muted")
+        note = el(
+            "p",
+            "n=0 — the mind hasn't yet learned to doubt itself. Brier appears after the first calibrated event forecasts.",
+            cls="muted",
+        )
     else:
         brier = cal.get("brier")
         base = cal.get("no_skill_baseline")
@@ -934,6 +989,7 @@ def calibration_html(state: dict[str, Any]) -> str:
 def breed_gate_html(gate: dict[str, Any]) -> str:
     """The REAL reproduction gate — proven-edge count + one-new-since-birth. Replaces
     the retired goodwill leverage ladder; reproduction gates on proven edge now."""
+
     def check(ok: bool, label: str) -> str:
         return el(
             "li",
@@ -947,13 +1003,17 @@ def breed_gate_html(gate: dict[str, Any]) -> str:
         el("div", "// REPRODUCTION GATE", cls="eyebrow"),
         el(
             "ul",
-            check(gate["have_edges"], f"≥{gate['need']} proven edges  [{gate['proven']}/{gate['need']}]"),
+            check(
+                gate["have_edges"],
+                f"≥{gate['need']} proven edges  [{gate['proven']}/{gate['need']}]",
+            ),
             check(gate["have_new"], f"1 new edge since last birth  [{gate['new_since']}]"),
             cls="gatelist",
         ),
         el(
             "p",
-            "Breed-ready ✓ — children inherit only proven DNA." if gate["ready"]
+            "Breed-ready ✓ — children inherit only proven DNA."
+            if gate["ready"]
             else "Reproduction locked — graduate a new edge to breed.",
             cls="muted",
         ),
@@ -983,7 +1043,13 @@ def positions_html(state: dict[str, Any]) -> str:
                 el("span", esc(side), cls="pill"),
                 el("b", esc(coin)),
                 esc(f" {abs(size):g} @ ${float(p.get('entryPx', 0) or 0):,.2f} "),
-                el("span", esc(_fmt_money(up)), cls="pos-pnl", data_coin=coin, style=f"color:{color};font-weight:700"),
+                el(
+                    "span",
+                    esc(_fmt_money(up)),
+                    cls="pos-pnl",
+                    data_coin=coin,
+                    style=f"color:{color};font-weight:700",
+                ),
                 el("span", esc(f" liq ${float(p.get('liquidationPx') or 0):,.0f}"), cls="muted"),
                 cls="posrow",
             )
@@ -1012,7 +1078,11 @@ def techniques_html(state: dict[str, Any]) -> str:
         w = float(e.get("weight", 1.0) or 1.0)
         trades = int(e.get("trades", 0) or 0)
         edge = float(e.get("e", 0.0) or 0.0)
-        flag = el("span", "PROVEN", cls="pflag") if tid in proven_ids else el("span", "on trial", cls="pill dim")
+        flag = (
+            el("span", "PROVEN", cls="pflag")
+            if tid in proven_ids
+            else el("span", "on trial", cls="pill dim")
+        )
         fit_cls = "up" if edge > 0 else "down" if edge < 0 else "muted"
         fit = (
             el("span", esc(f"{_fmt_edge(edge)} edge · {trades} tr"), cls=fit_cls)
@@ -1022,7 +1092,13 @@ def techniques_html(state: dict[str, Any]) -> str:
         rows.append(
             el(
                 "li",
-                el("div", el("b", esc(tid)), flag, el("span", esc(f"w {w:.2f}"), cls="wpct"), cls="loadtop"),
+                el(
+                    "div",
+                    el("b", esc(tid)),
+                    flag,
+                    el("span", esc(f"w {w:.2f}"), cls="wpct"),
+                    cls="loadtop",
+                ),
                 el("div", el("i", style=f"width:{min(100, w * 100):.0f}%"), cls="wbar"),
                 el("div", fit, cls="loadsub"),
                 cls="load",
@@ -1053,7 +1129,11 @@ def books_html(state: dict[str, Any]) -> str:
         el(
             "div",
             el("div", "C · CARRY FLOOR", cls="bookhead"),
-            el("p", esc(f"Δ-neutral funding harvest · {npos} perp open · {cal_n} event settles"), cls="muted"),
+            el(
+                "p",
+                esc(f"Δ-neutral funding harvest · {npos} perp open · {cal_n} event settles"),
+                cls="muted",
+            ),
             cls="book",
         ),
         cls="books",
@@ -1077,11 +1157,20 @@ def onchain_html(state: dict[str, Any]) -> str:
     if gas.get("status"):
         gas_line = el(
             "div",
-            esc(f"beacon gas: {gas.get('baseEth', 0):.5f} Base ETH · ~{gas.get('beaconRunway', 0)} beacons"),
+            esc(
+                f"beacon gas: {gas.get('baseEth', 0):.5f} Base ETH · ~{gas.get('beaconRunway', 0)} beacons"
+            ),
             cls="muted",
         )
     idrow = (
-        el("div", el("span", "ERC-8004", cls="pill"), esc(" agent "), el("b", esc(f"#{aid}")), esc(f" on {ident.get('chain', 'base:8453')}"), cls="idrow")
+        el(
+            "div",
+            el("span", "ERC-8004", cls="pill"),
+            esc(" agent "),
+            el("b", esc(f"#{aid}")),
+            esc(f" on {ident.get('chain', 'base:8453')}"),
+            cls="idrow",
+        )
         if aid
         else el("p", "No onchain identity yet.", cls="muted")
     )
@@ -1209,7 +1298,9 @@ def dna_script(state: dict[str, Any], proven: list[dict[str, Any]]) -> str:
         "archetype": persona.get("archetype", ""),
         "catchphrase": persona.get("catchphrase", ""),
         "proven": len(proven),
-        "authored": int((state["reputation"].get("evolution") or {}).get("self_authored_techniques", 0) or 0),
+        "authored": int(
+            (state["reputation"].get("evolution") or {}).get("self_authored_techniques", 0) or 0
+        ),
         "record": f"{rec['closes']} closes · {_fmt_money(rec['pnl'])}",
         "fingerprint": g["fingerprint"],
     }
@@ -1487,7 +1578,14 @@ def _header_html(state: dict[str, Any], proven: list[dict[str, Any]]) -> str:
         el(
             "div",
             el("span", esc(f"{mode} · heartbeat {hb}"), cls="livedot"),
-            el("a", "𝕏 Share", cls="sharebtn", href=share_url(metabolism, name, len(proven)), target="_blank", rel="noopener"),
+            el(
+                "a",
+                "𝕏 Share",
+                cls="sharebtn",
+                href=share_url(metabolism, name, len(proven)),
+                target="_blank",
+                rel="noopener",
+            ),
             el("a", "Leaderboard ↗", cls="sharebtn", href="leaderboard.html"),
             cls="headright",
         ),
@@ -1495,7 +1593,9 @@ def _header_html(state: dict[str, Any], proven: list[dict[str, Any]]) -> str:
     )
 
 
-def _substance_html(state: dict[str, Any], proven: list[dict[str, Any]], gate: dict[str, Any]) -> str:
+def _substance_html(
+    state: dict[str, Any], proven: list[dict[str, Any]], gate: dict[str, Any]
+) -> str:
     """SUBSTANCE — the beating heart: bench, proven techniques, proven-DNA helix +
     lineage graph, calibration + the reproduction gate."""
     helix_col = el(
@@ -1523,7 +1623,11 @@ def _proof_html(state: dict[str, Any]) -> str:
     the onchain identity + reputation scorecard."""
     return (
         el("details", el("summary", "// THE THREE BOOKS"), books_html(state))
-        + el("details", el("summary", "// FULL LOADOUT · every adopted technique"), techniques_html(state))
+        + el(
+            "details",
+            el("summary", "// FULL LOADOUT · every adopted technique"),
+            techniques_html(state),
+        )
         + el("details", el("summary", "// LINEAGE · children & inheritance"), family_html(state))
         + el("details", el("summary", "// ONCHAIN IDENTITY & SCORECARD"), onchain_html(state))
     )
@@ -1545,7 +1649,9 @@ def render(state: dict[str, Any]) -> str:
     foot = el(
         "div",
         el("span", lion("14px"), cls="lionmark"),
-        esc(f" //GEMACH · a mind that must prove edge to survive · rendered {datetime.now(UTC).isoformat(timespec='seconds')}"),
+        esc(
+            f" //GEMACH · a mind that must prove edge to survive · rendered {datetime.now(UTC).isoformat(timespec='seconds')}"
+        ),
         cls="foot",
     )
     scripts = live_sync_script(state) + dna_script(state, proven)
@@ -1576,7 +1682,12 @@ def render(state: dict[str, Any]) -> str:
     )
 
 
-def render_html(state: dict[str, Any], identity: str = "", journal: list | None = None, messages: list | None = None) -> str:
+def render_html(
+    state: dict[str, Any],
+    identity: str = "",
+    journal: list | None = None,
+    messages: list | None = None,
+) -> str:
     """Back-compat shim: accept a bare metabolism dict (as the old tests do) and wrap
     it into the full state the pure :func:`render` needs, reading the rest from home."""
     if "metabolism" in state and "genome" in state:
@@ -1591,9 +1702,13 @@ def render_html(state: dict[str, Any], identity: str = "", journal: list | None 
         "style": style,
         "proven_markets": load_json(h / "forge" / "proven_markets.json", {}).get("pairs", []),
         "techniques": _load_techniques(h, style.get("adopted", [])),
-        "authored_cards": _load_authored(h, (metabolism.get("onchain_identity") or {}).get("agentId", "")),
+        "authored_cards": _load_authored(
+            h, (metabolism.get("onchain_identity") or {}).get("agentId", "")
+        ),
         "journal": journal if journal is not None else read_jsonl(h / "journal.jsonl"),
-        "telepathy": messages if messages is not None else read_jsonl(h / "telepathy" / "bus.jsonl"),
+        "telepathy": messages
+        if messages is not None
+        else read_jsonl(h / "telepathy" / "bus.jsonl"),
         "positions": load_json(h / "positions.json", {}),
         "gas": load_json(h / "gas.json", {}),
         "leaderboard": load_json(h / "leaderboard.json", {}),
@@ -1631,7 +1746,9 @@ def main() -> int:
     sub = parser.add_subparsers(dest="command", required=True)
     p_render = sub.add_parser("render")
     p_render.add_argument("--out")
-    p_render.add_argument("--no-live", action="store_true", help="skip the live HL positions refresh")
+    p_render.add_argument(
+        "--no-live", action="store_true", help="skip the live HL positions refresh"
+    )
     p_serve = sub.add_parser("serve")
     p_serve.add_argument("--out")
     p_serve.add_argument("--port", type=int, default=8787)

--- a/scripts/evolve.py
+++ b/scripts/evolve.py
@@ -53,7 +53,8 @@ def proven_edge_techniques() -> list[dict[str, Any]]:
     """Adopted techniques with REAL live edge (>= PROVEN_MIN_TRADES closes, positive
     expectancy) — the inheritable DNA reproduction gates on (the fitness Spore.fun lacked)."""
     return [
-        e for e in _adopted()
+        e
+        for e in _adopted()
         if int(e.get("trades", 0)) >= PROVEN_MIN_TRADES and float(e.get("e", 0.0)) > 0
     ]
 
@@ -66,8 +67,9 @@ def self_authored_adopted(state: dict[str, Any]) -> list[str]:
     for e in _adopted():
         try:
             tech = json.loads(
-                (gclaw_home() / "forge" / "techniques" / e["id"] / "technique.json")
-                .read_text(encoding="utf-8")
+                (gclaw_home() / "forge" / "techniques" / e["id"] / "technique.json").read_text(
+                    encoding="utf-8"
+                )
             )
             if str(tech.get("author")) == aid:
                 out.append(e["id"])
@@ -82,13 +84,18 @@ def replication_gate(state: dict[str, Any]) -> tuple[bool, str, list[dict[str, A
     pool can't spawn child after child — only genuine evolution breeds)."""
     proven = proven_edge_techniques()
     if len(proven) < REPLICATE_MIN_EDGE:
-        return (False, f"proven-edge {len(proven)}/{REPLICATE_MIN_EDGE} — graduate more live edge first", proven)
+        return (
+            False,
+            f"proven-edge {len(proven)}/{REPLICATE_MIN_EDGE} — graduate more live edge first",
+            proven,
+        )
     if len(state.get("children", [])) >= MAX_CHILDREN:
         return (False, f"child cap reached ({MAX_CHILDREN})", proven)
     last = state.get("last_replicate_edge_count", 0)
     if len(proven) <= last:
         return (False, f"no new proven edge since last birth ({len(proven)} <= {last})", proven)
     return (True, "proven-edge gate met", proven)
+
 
 # Swarm roles a child can be born into (mirrors the original Gclaw swarm).
 ROLES = {
@@ -192,11 +199,20 @@ def cmd_replicate(args: argparse.Namespace) -> None:
     # spawn when armed; otherwise log that the proven-edge gate is met. Mirrors the
     # event-desk / carry shadow→live pattern.
     if not _reproduce_live():
-        print(json.dumps({
-            "ok": True, "would_replicate": True, "dry_run": True, "name": name, "role": role,
-            "mutation": mutation, "inherits": [e["id"] for e in proven],
-            "note": "proven-edge gate MET — set GCLAW_REPRODUCE_LIVE=1 to spawn the child",
-        }))
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "would_replicate": True,
+                    "dry_run": True,
+                    "name": name,
+                    "role": role,
+                    "mutation": mutation,
+                    "inherits": [e["id"] for e in proven],
+                    "note": "proven-edge gate MET — set GCLAW_REPRODUCE_LIVE=1 to spawn the child",
+                }
+            )
+        )
         return
     if role not in ROLES:
         sys.exit(f"--role must be one of {sorted(ROLES)}")
@@ -244,7 +260,9 @@ def cmd_replicate(args: argparse.Namespace) -> None:
     )
     soul = give_soul(child_dir, name, born)
     announce_birth(name, role, mutation)
-    print(f"Replicated child '{name}' ({role}) at {child_dir} — inherits {[e['id'] for e in proven]}")
+    print(
+        f"Replicated child '{name}' ({role}) at {child_dir} — inherits {[e['id'] for e in proven]}"
+    )
     print(f"  soul: {soul}")
     print(f"  mutation: {mutation}")
     print(f"  children: {len(state['children'])}/{MAX_CHILDREN}")
@@ -314,7 +332,9 @@ def cmd_recode(_args: argparse.Namespace) -> None:
     authored = self_authored_adopted(state)
     state["recodes"] = len(authored)
     save_state(state)
-    append_journal({"ts": now_iso(), "event": "recode", "count": len(authored), "authored": authored})
+    append_journal(
+        {"ts": now_iso(), "event": "recode", "count": len(authored), "authored": authored}
+    )
     print(json.dumps({"ok": True, "recodes": len(authored), "authored": authored}))
 
 
@@ -326,7 +346,9 @@ def cmd_capabilities(_: argparse.Namespace) -> None:
     print(f"  {'✓' if allowed else '·'} replicate     ({reason})")
     print(f"  self-recodes (authored + adopted): {len(authored)} — {authored}")
     print(f"  children: {len(state.get('children', []))}/{MAX_CHILDREN}")
-    print(f"  reproduction: {'ARMED (live)' if _reproduce_live() else 'dry-run (set GCLAW_REPRODUCE_LIVE=1 to spawn)'}")
+    print(
+        f"  reproduction: {'ARMED (live)' if _reproduce_live() else 'dry-run (set GCLAW_REPRODUCE_LIVE=1 to spawn)'}"
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -334,7 +356,11 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_rep = sub.add_parser("replicate", help="spawn a child on proven-edge (or --auto)")
-    p_rep.add_argument("--auto", action="store_true", help="derive name/role/mutation + gate-check deterministically")
+    p_rep.add_argument(
+        "--auto",
+        action="store_true",
+        help="derive name/role/mutation + gate-check deterministically",
+    )
     p_rep.add_argument("--name", help="child name (required unless --auto)")
     p_rep.add_argument("--role", choices=sorted(ROLES), help="swarm role (required unless --auto)")
     p_rep.add_argument("--mutation", help="how the child differs (required unless --auto)")

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -95,6 +95,8 @@ HORIZON_BY_TECHNIQUE = {"momentum-stack": 24, "stop-hunt-revert": 4}
 #   taker: 0.045%/side fee + ~3bp slippage into the book/cascade -> ~7.5bp
 TAKER_FEE = 0.00075  # taker fee (4.5bp) + realistic slippage (3bp) per side
 MAKER_FEE = 0.00015  # maker fee (1.5bp), no slippage — you are the resting order
+
+
 # Backtest execution mode must MATCH the live executor (hl_perp.js), and it does: BOTH
 # read GCLAW_FORGE_MAKER_ENTRY. Unset (default) → the executor opens isMarket:true (taker)
 # with an attached TP/SL and the backtest charges taker entry. Set to 1 → the executor
@@ -938,24 +940,35 @@ def cmd_author(args: argparse.Namespace) -> dict[str, Any]:
     violations = validate_signal_src(body)
     if violations:
         return {
-            "ok": False, "authored": tid, "rejected": "sandbox",
-            "violations": violations, "proven": False, "adopted": False,
+            "ok": False,
+            "authored": tid,
+            "rejected": "sandbox",
+            "violations": violations,
+            "proven": False,
+            "adopted": False,
         }
     d = tech_dir(tid)
     if d.exists() and not args.force:
         die(f"technique '{tid}' exists — use --force to revise it, or fork it under a new name")
     d.mkdir(parents=True, exist_ok=True)
     tech = {
-        "id": tid, "name": args.name, "kind": args.kind, "author": agent_id(),
-        "parent": args.parent, "claim": args.claim or "", "status": "draft",
+        "id": tid,
+        "name": args.name,
+        "kind": args.kind,
+        "author": agent_id(),
+        "parent": args.parent,
+        "claim": args.claim or "",
+        "status": "draft",
         "created_at": now_iso(),
     }
     save_technique(tech)
     (d / "signal.py").write_text(body, encoding="utf-8")
     (d / "SKILL.md").write_text(
         SKILL_TEMPLATE.format(
-            name=args.name, kind=args.kind,
-            claim=args.claim or "(state the edge)", author=tech["author"],
+            name=args.name,
+            kind=args.kind,
+            claim=args.claim or "(state the edge)",
+            author=tech["author"],
         ),
         encoding="utf-8",
     )
@@ -964,13 +977,20 @@ def cmd_author(args: argparse.Namespace) -> dict[str, Any]:
     try:
         card = backtest(tid, args.coin, args.interval, args.limit)
     except ValueError as exc:
-        return {"ok": True, "authored": tid, "proven": False, "adopted": False,
-                "verdict": f"could not backtest ({exc}); kept as draft"}
+        return {
+            "ok": True,
+            "authored": tid,
+            "proven": False,
+            "adopted": False,
+            "verdict": f"could not backtest ({exc}); kept as draft",
+        }
     (d / "card.json").write_text(json.dumps(card, indent=2), encoding="utf-8")
     tech["status"] = "proven" if card["proven"] else "draft"
     tech["card"] = {
-        "coin": card["coin"], "interval": card["interval"],
-        "oos": card["out_of_sample"], "proven": card["proven"],
+        "coin": card["coin"],
+        "interval": card["interval"],
+        "oos": card["out_of_sample"],
+        "proven": card["proven"],
     }
     save_technique(tech)
     adopted = False
@@ -981,10 +1001,15 @@ def cmd_author(args: argparse.Namespace) -> dict[str, Any]:
         save_style(style)
         adopted = True
     return {
-        "ok": True, "authored": tid, "proven": card["proven"], "adopted": adopted, "card": card,
+        "ok": True,
+        "authored": tid,
+        "proven": card["proven"],
+        "adopted": adopted,
+        "card": card,
         "verdict": (
             "adopted — graduated on out-of-sample edge"
-            if adopted else "kept as draft — did not clear the OOS gate; fork and improve it"
+            if adopted
+            else "kept as draft — did not clear the OOS gate; fork and improve it"
         ),
     }
 
@@ -1773,15 +1798,28 @@ def _size_via_brain(
     """
     sz = subprocess.run(
         [
-            "uv", "run", "--no-project", "python3", str(SCRIPT_DIR / "sizing.py"), "size",
-            "--equity", str(equity),
-            "--price", str(price),
-            "--atr-pct", str(atr_pct),
-            "--win-rate", str(edge.get("win_rate", 0.5)),
-            "--payoff", str(edge.get("payoff", 1.5)),
-            "--trades", str(edge.get("trades", 0)),
-            "--goodwill", str(float(load_metabolism().get("goodwill", 0) or 0)),
-            "--confidence", str(confidence),
+            "uv",
+            "run",
+            "--no-project",
+            "python3",
+            str(SCRIPT_DIR / "sizing.py"),
+            "size",
+            "--equity",
+            str(equity),
+            "--price",
+            str(price),
+            "--atr-pct",
+            str(atr_pct),
+            "--win-rate",
+            str(edge.get("win_rate", 0.5)),
+            "--payoff",
+            str(edge.get("payoff", 1.5)),
+            "--trades",
+            str(edge.get("trades", 0)),
+            "--goodwill",
+            str(float(load_metabolism().get("goodwill", 0) or 0)),
+            "--confidence",
+            str(confidence),
         ],
         capture_output=True,
         text=True,
@@ -1837,9 +1875,15 @@ def _intent(
     # skip. The live stop below is ATR-derived, but the DECISION must carry one first.
     if float(decision.get("stop_pct") or 0) <= 0:
         return {
-            "technique": tid, "coin": coin, "side": decision["action"], "leverage": leverage,
-            "sl_pct": 0.0, "confidence": float(decision.get("confidence") or 0),
-            "notional": 0, "risk_usd": 0.0, "reason": str(decision.get("reason") or "")[:120],
+            "technique": tid,
+            "coin": coin,
+            "side": decision["action"],
+            "leverage": leverage,
+            "sl_pct": 0.0,
+            "confidence": float(decision.get("confidence") or 0),
+            "notional": 0,
+            "risk_usd": 0.0,
+            "reason": str(decision.get("reason") or "")[:120],
         }
     atr_pct = float(intel.get("atr_pct") or decision.get("stop_pct") or 1.0)
     price = float(intel.get("price") or decision.get("price") or 0)
@@ -2104,8 +2148,16 @@ def _memory_edge_ok(technique: str, regime: str) -> tuple[bool, dict[str, Any]]:
     """
     out = subprocess.run(
         [
-            "uv", "run", "--no-project", "python3", str(SCRIPT_DIR / "memory.py"),
-            "expectancy", "--technique", technique, "--regime", regime,
+            "uv",
+            "run",
+            "--no-project",
+            "python3",
+            str(SCRIPT_DIR / "memory.py"),
+            "expectancy",
+            "--technique",
+            technique,
+            "--regime",
+            regime,
         ],
         capture_output=True,
         text=True,
@@ -2182,9 +2234,11 @@ def _gate_intents(
             continue
         # Reuse the per-coin memory read stashed by cmd_run (cmd_run sets edge_real_mem
         # so the gate never re-queries memory.py per intent).
-        ok = bool(i.get("edge_real_mem")) if "edge_real_mem" in i else _memory_edge_ok(
-            i["technique"], i.get("regime", "range")
-        )[0]
+        ok = (
+            bool(i.get("edge_real_mem"))
+            if "edge_real_mem" in i
+            else _memory_edge_ok(i["technique"], i.get("regime", "range"))[0]
+        )
         # Cold-start means STILL-BOOTSTRAPPING, not LOSING: a technique earns bounded
         # half-size probes until it has a fair live sample (MIN_LIVE_SAMPLE closes). The
         # old window (< 3) benched a technique the moment it hit 3 trades — but the
@@ -2310,9 +2364,7 @@ def cmd_run(args: argparse.Namespace) -> dict[str, Any]:
             save_pending(pending)
             result["attribution"] = {"coin": top["coin"], "credit_to": ref}
     elif args.execute:
-        result["executed"] = {
-            "skipped": "no intent cleared the edge_real + conviction gate"
-        }
+        result["executed"] = {"skipped": "no intent cleared the edge_real + conviction gate"}
     return result
 
 
@@ -2409,7 +2461,9 @@ def build_parser() -> argparse.ArgumentParser:
         "author", help="propose a signal body; validate+backtest+adopt-if-proven (never executes)"
     )
     au.add_argument("--name", required=True)
-    au.add_argument("--signal-file", dest="signal_file", required=True, help="path to the signal.py body")
+    au.add_argument(
+        "--signal-file", dest="signal_file", required=True, help="path to the signal.py body"
+    )
     au.add_argument("--claim", default="")
     au.add_argument("--kind", choices=["lens", "edge"], default="edge")
     au.add_argument("--coin", default="BTC")

--- a/scripts/gmac_buy.js
+++ b/scripts/gmac_buy.js
@@ -22,8 +22,14 @@ const path = require('node:path');
 const GDEX_DIR = process.env.GDEX_SKILL_DIR || path.join(os.homedir(), 'gdex-skill');
 const WALLET_PATH = process.env.GCLAW_WALLET || [path.join(os.homedir(), '.gclaw', 'wallet.json'), path.join(os.homedir(), 'gdex-test-wallet.json')].find((p) => fs.existsSync(p)) || path.join(os.homedir(), 'gdex-test-wallet.json');
 const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
-const { ethers } = require(path.join(GDEX_DIR, 'node_modules', 'ethers'));
-const SDK = require(path.join(GDEX_DIR, 'dist'));
+// ethers + the GDEX SDK resolve from the GDEX skill dir at runtime; they're absent in the
+// pure-logic test/CI context (only reconcileSentinel is exercised there), so load them
+// tolerantly — the buy/sign paths that use them run only on the box where deps exist.
+let ethers, SDK;
+try {
+  ({ ethers } = require(path.join(GDEX_DIR, 'node_modules', 'ethers')));
+  SDK = require(path.join(GDEX_DIR, 'dist'));
+} catch { /* deps unavailable in CI/pure-test; network paths below won't run */ }
 
 const ETH_CHAIN = 1;
 const GMAC = '0xd96e84ddbc7cbe1d73c55b6fe8c64f3a6550deea';

--- a/scripts/hl_outcomes.js
+++ b/scripts/hl_outcomes.js
@@ -26,8 +26,14 @@ const path = require('node:path');
 
 const GDEX_DIR = process.env.GDEX_SKILL_DIR || path.join(os.homedir(), 'gdex-skill');
 const WALLET_PATH = process.env.GCLAW_WALLET || [path.join(os.homedir(), '.gclaw', 'wallet.json'), path.join(os.homedir(), 'gdex-test-wallet.json')].find((p) => fs.existsSync(p)) || path.join(os.homedir(), 'gdex-test-wallet.json');
-const { ethers } = require(path.join(GDEX_DIR, 'node_modules', 'ethers'));
-const SDK = require(path.join(GDEX_DIR, 'dist'));
+// ethers + the GDEX SDK resolve from the GDEX skill dir at runtime; they're absent in the
+// pure-logic test/CI context (only the classifiers below are exercised there), so load them
+// tolerantly — the sign-in/order paths that use them run only on the box where deps exist.
+let ethers, SDK;
+try {
+  ({ ethers } = require(path.join(GDEX_DIR, 'node_modules', 'ethers')));
+  SDK = require(path.join(GDEX_DIR, 'dist'));
+} catch { /* deps unavailable in CI/pure-test; network paths below won't run */ }
 
 const HL_CHAIN_ID = 42161;
 

--- a/scripts/outcomes.py
+++ b/scripts/outcomes.py
@@ -140,11 +140,15 @@ def _place_live_order(side: dict[str, Any], stake: float) -> dict[str, Any]:
     return _run_outcomes_js(
         [
             "order",
-            "--outcome", str(side["outcomeId"]),
-            "--coin", str(side["coin"]),
+            "--outcome",
+            str(side["outcomeId"]),
+            "--coin",
+            str(side["coin"]),
             "--buy",
-            "--price", str(price),
-            "--size", str(size),
+            "--price",
+            str(price),
+            "--size",
+            str(size),
             "--market",
         ]
     )
@@ -290,7 +294,9 @@ def evaluate_bet(
     return {"ok": True, "side": side, "edge": edge}
 
 
-def _new_ticket(side: dict[str, Any], prob: float, stake: float, edge: float, reason: str) -> dict[str, Any]:
+def _new_ticket(
+    side: dict[str, Any], prob: float, stake: float, edge: float, reason: str
+) -> dict[str, Any]:
     return {
         "coin": side["coin"],
         "outcomeId": side["outcomeId"],
@@ -395,14 +401,18 @@ def cmd_resolve(_args: argparse.Namespace) -> dict[str, Any]:
         t["resolved"] = True
         t["outcome"] = outcome
         t["brier"] = round((float(t["prob"]) - outcome) ** 2, 6)
-        t["settle_pnl"] = round(float(s.get("closedPnl", 0)), 6)  # informational; autosettle books it
+        t["settle_pnl"] = round(
+            float(s.get("closedPnl", 0)), 6
+        )  # informational; autosettle books it
         t["resolved_at"] = now_iso()
         resolved_now.append(t)
     save_ledger(led)
     return {
         "ok": True,
         "resolved": len(resolved_now),
-        "tickets": [{"coin": t["coin"], "outcome": t["outcome"], "brier": t["brier"]} for t in resolved_now],
+        "tickets": [
+            {"coin": t["coin"], "outcome": t["outcome"], "brier": t["brier"]} for t in resolved_now
+        ],
         "aggregates": led["aggregates"],
     }
 
@@ -410,7 +420,9 @@ def cmd_resolve(_args: argparse.Namespace) -> dict[str, Any]:
 # ── CLI verbs ────────────────────────────────────────────────────────────────
 
 
-def partition_edgeable(sides: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def partition_edgeable(
+    sides: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Split the board into (edgeable, efficient) by market category.
 
     A side is edgeable when its category is in ``EDGEABLE_CATEGORIES`` (a dated crypto

--- a/scripts/predict.js
+++ b/scripts/predict.js
@@ -28,7 +28,16 @@ const https = require('node:https');
 const GDEX_DIR = process.env.GDEX_SKILL_DIR || path.join(os.homedir(), 'gdex-skill');
 // Lazy keccak — only the root/roundId paths need ethers, so the file-io helpers
 // (readJson/readJsonl/writeAtomic) and resolve logic stay unit-testable without it.
-const ethers = () => require(path.join(GDEX_DIR, 'node_modules', 'ethers')).ethers;
+// Resolve ethers from local node_modules first (installed in CI/tests for the keccak
+// paths), falling back to the GDEX skill's copy on the box.
+const ethers = () => {
+  try {
+    const e = require('ethers');
+    return e.ethers ?? e;
+  } catch {
+    return require(path.join(GDEX_DIR, 'node_modules', 'ethers')).ethers;
+  }
+};
 const WALLET_PATH = process.env.GCLAW_WALLET || [path.join(os.homedir(), '.gclaw', 'wallet.json'), path.join(os.homedir(), 'gdex-test-wallet.json')].find((p) => fs.existsSync(p));
 const GCLAW_HOME = process.env.GCLAW_HOME || path.join(os.homedir(), '.gclaw');
 const DIR = path.join(GCLAW_HOME, 'predictions');

--- a/scripts/reputation.py
+++ b/scripts/reputation.py
@@ -24,7 +24,9 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-SCRIPT_DIR = Path(os.environ.get("GCLAW_SKILL_DIR", str(Path(__file__).resolve().parent.parent))) / "scripts"
+SCRIPT_DIR = (
+    Path(os.environ.get("GCLAW_SKILL_DIR", str(Path(__file__).resolve().parent.parent))) / "scripts"
+)
 
 
 def home() -> Path:
@@ -42,8 +44,18 @@ def _economics() -> dict[str, Any]:
     """The settled trading record (audit_economics derives it from real closed fills)."""
     try:
         out = subprocess.run(
-            ["uv", "run", "--no-project", "python3", str(SCRIPT_DIR / "audit_economics.py"), "report"],
-            capture_output=True, text=True, timeout=120, check=False,
+            [
+                "uv",
+                "run",
+                "--no-project",
+                "python3",
+                str(SCRIPT_DIR / "audit_economics.py"),
+                "report",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
         ).stdout
         i = out.find("{")
         return json.loads(out[i:]) if i >= 0 else {}
@@ -122,11 +134,17 @@ def cmd_publish(_a: argparse.Namespace) -> int:
     tmp.write_text(json.dumps(sc, indent=2) + "\n", encoding="utf-8")
     tmp.replace(path)
     ev = sc["evolution"]
-    print(json.dumps({
-        "ok": True, "published": str(path),
-        "realized_pnl_usd": sc["trading"]["realized_pnl_usd"],
-        "proven_edge": ev["proven_edge_count"], "self_authored": ev["self_authored_techniques"],
-    }))
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "published": str(path),
+                "realized_pnl_usd": sc["trading"]["realized_pnl_usd"],
+                "proven_edge": ev["proven_edge_count"],
+                "self_authored": ev["self_authored_techniques"],
+            }
+        )
+    )
     return 0
 
 

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -24,8 +24,20 @@ def _full() -> dict:
             "leverage_cap": 3,
             "breaker": {"allow_entry": True, "drawdown_pct": 0.1, "hwm": 202.36},
             "intents": [
-                {"coin": "xyz:SNDK", "side": "long", "confidence": 0.542, "proven": False, "technique": "stop-hunt-revert"},
-                {"coin": "SOL", "side": "short", "confidence": 0.371, "proven": True, "technique": "contrarian-flow"},
+                {
+                    "coin": "xyz:SNDK",
+                    "side": "long",
+                    "confidence": 0.542,
+                    "proven": False,
+                    "technique": "stop-hunt-revert",
+                },
+                {
+                    "coin": "SOL",
+                    "side": "short",
+                    "confidence": 0.371,
+                    "proven": True,
+                    "technique": "contrarian-flow",
+                },
             ],
         },
         "economics": {"n": 11, "win_rate": 0.091, "expectancy": -1.282, "verdict": "🔴 still -EV"},
@@ -51,7 +63,9 @@ def test_briefing_has_every_section_and_the_live_numbers():
 
 def test_open_positions_are_summarised_not_hidden():
     d = _full()
-    d["account"]["positions"] = [{"coin": "xyz:MU", "size": "2", "entryPx": 150, "unrealizedPnl": 1.25}]
+    d["account"]["positions"] = [
+        {"coin": "xyz:MU", "size": "2", "entryPx": 150, "unrealizedPnl": 1.25}
+    ]
     b = briefing.render_briefing(d)
     assert "1 OPEN" in b and "xyz:MU long 2.0@$150.00" in b
     # the ACCOUNT line must not claim a flat book when positioned (the closer's generic
@@ -77,8 +91,12 @@ def test_no_intents_and_all_chop_render_cleanly():
 
 def test_render_never_raises_on_empty_or_partial_data():
     # a blinded cycle is worse than a thin briefing — it must degrade, not crash
-    for d in ({}, {"meta": None, "intel": None, "forge": None, "account": None, "economics": None},
-              {"forge": {"intents": [{"coin": "X"}]}}, {"account": {"equity": "?"}}):
+    for d in (
+        {},
+        {"meta": None, "intel": None, "forge": None, "account": None, "economics": None},
+        {"forge": {"intents": [{"coin": "X"}]}},
+        {"account": {"equity": "?"}},
+    ):
         b = briefing.render_briefing(d)
         assert isinstance(b, str) and "Cycle briefing" in b
 
@@ -86,16 +104,47 @@ def test_render_never_raises_on_empty_or_partial_data():
 def _crypto_binary_market() -> dict:
     return {
         "sides": [
-            {"outcomeId": 173, "name": "Argentina", "side": "No", "coin": "#1731", "price": 0.81,
-             "volumeUsd": 287125.0, "category": "sports"},
-            {"outcomeId": 713, "name": "Recurring", "side": "Yes", "coin": "#7130", "price": 0.75,
-             "volumeUsd": 188506.0, "category": "crypto-price",
-             "resolution": {"underlying": "BTC", "targetPrice": 59122, "expiry": "20260702-0600", "period": "1d"}},
+            {
+                "outcomeId": 173,
+                "name": "Argentina",
+                "side": "No",
+                "coin": "#1731",
+                "price": 0.81,
+                "volumeUsd": 287125.0,
+                "category": "sports",
+            },
+            {
+                "outcomeId": 713,
+                "name": "Recurring",
+                "side": "Yes",
+                "coin": "#7130",
+                "price": 0.75,
+                "volumeUsd": 188506.0,
+                "category": "crypto-price",
+                "resolution": {
+                    "underlying": "BTC",
+                    "targetPrice": 59122,
+                    "expiry": "20260702-0600",
+                    "period": "1d",
+                },
+            },
         ],
         "edgeable": [
-            {"outcomeId": 713, "name": "Recurring", "side": "Yes", "coin": "#7130", "price": 0.75,
-             "volumeUsd": 188506.0, "category": "crypto-price",
-             "resolution": {"underlying": "BTC", "targetPrice": 59122, "expiry": "20260702-0600", "period": "1d"}},
+            {
+                "outcomeId": 713,
+                "name": "Recurring",
+                "side": "Yes",
+                "coin": "#7130",
+                "price": 0.75,
+                "volumeUsd": 188506.0,
+                "category": "crypto-price",
+                "resolution": {
+                    "underlying": "BTC",
+                    "targetPrice": 59122,
+                    "expiry": "20260702-0600",
+                    "period": "1d",
+                },
+            },
         ],
         "edgeable_count": 1,
     }
@@ -115,8 +164,17 @@ def test_event_desk_shows_edgeable_market_with_resolution_criteria():
 def test_event_desk_shows_explicit_no_edgeable_market_when_only_sports():
     d = _full()
     d["outcomes"] = {
-        "sides": [{"outcomeId": 173, "name": "Argentina", "side": "No", "coin": "#1731",
-                   "price": 0.81, "volumeUsd": 287125.0, "category": "sports"}],
+        "sides": [
+            {
+                "outcomeId": 173,
+                "name": "Argentina",
+                "side": "No",
+                "coin": "#1731",
+                "price": 0.81,
+                "volumeUsd": 287125.0,
+                "category": "sports",
+            }
+        ],
         "edgeable": [],
         "edgeable_count": 0,
         "no_edgeable_market": "1 sides clear the $10,000 floor but all are efficient (sports/World-Cup)",
@@ -157,5 +215,8 @@ def test_spot_reference_below_strike_and_low_priced_precision() -> None:
 
 def test_spot_reference_missing_mark_is_empty_never_raises() -> None:
     """No mark for the underlying (or a non-price-binary side) → empty suffix, no crash."""
-    assert briefing._spot_reference({"resolution": {"underlying": "BTC", "targetPrice": 59122}}, {}) == ""
+    assert (
+        briefing._spot_reference({"resolution": {"underlying": "BTC", "targetPrice": 59122}}, {})
+        == ""
+    )
     assert briefing._spot_reference({"description": "some sport"}, {"BTC": {"price": 1}}) == ""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -57,7 +57,11 @@ def _state(**overrides: object) -> dict[str, object]:
             {"technique": "vol-momentum", "coin": "xyz:MU", "oos_n": 129, "t": 4.74},
         ],
         "techniques": {
-            "stop-hunt-revert": {"id": "stop-hunt-revert", "status": "proven", "card": {"proven": True, "oos": {"n": 13}}},
+            "stop-hunt-revert": {
+                "id": "stop-hunt-revert",
+                "status": "proven",
+                "card": {"proven": True, "oos": {"n": 13}},
+            },
         },
         "authored_cards": [
             {
@@ -244,7 +248,13 @@ def test_positions_panel_flat_then_open():
             "equity": 50.0,
             "managed": "0xabc",
             "positions": [
-                {"coin": "ETH", "size": -0.1, "entryPx": 1700, "unrealizedPnl": -2.18, "liquidationPx": 3386}
+                {
+                    "coin": "ETH",
+                    "size": -0.1,
+                    "entryPx": 1700,
+                    "unrealizedPnl": -2.18,
+                    "liquidationPx": 3386,
+                }
             ],
         }
     )
@@ -258,7 +268,12 @@ def test_render_escapes_untrusted_technique_claims():
     # A malicious claim must be escaped, never injected as live markup.
     state = _state()
     state["authored_cards"] = [
-        {"id": "x", "claim": "<img src=x onerror=alert(1)>", "status": "draft", "card": {"oos": {"n": 0}}}
+        {
+            "id": "x",
+            "claim": "<img src=x onerror=alert(1)>",
+            "status": "draft",
+            "card": {"oos": {"n": 0}},
+        }
     ]
     html = dashboard.render(state)
     assert "<img src=x onerror" not in html
@@ -318,14 +333,18 @@ def test_sigil_is_a_clean_glyph():
 
 
 def test_hl_perp_reads_perp_state_from_public_api():
-    src = (Path(__file__).resolve().parent.parent / "scripts" / "hl_perp.js").read_text(encoding="utf-8")
+    src = (Path(__file__).resolve().parent.parent / "scripts" / "hl_perp.js").read_text(
+        encoding="utf-8"
+    )
     fs = src[src.index("async function fullState") : src.index("async function fullState") + 700]
     assert "hlInfo(" in fs
     assert "skill.getHlClearinghouseState" not in fs
 
 
 def test_leaderboard_verifier_counts_the_perp_wallet():
-    src = (Path(__file__).resolve().parent.parent / "leaderboard" / "leaderboard.html").read_text(encoding="utf-8")
+    src = (Path(__file__).resolve().parent.parent / "leaderboard" / "leaderboard.html").read_text(
+        encoding="utf-8"
+    )
     assert "clearinghouseState" in src
     assert "accountValue" in src
     assert "hold" in src

--- a/tests/test_evolve.py
+++ b/tests/test_evolve.py
@@ -64,7 +64,9 @@ def test_goodwill_is_irrelevant_proven_edge_gates(metabolism_fixture, gclaw_home
     state = json.loads((gclaw_home / "metabolism.json").read_text(encoding="utf-8"))
     assert len(state["children"]) == 1
     assert state["last_replicate_edge_count"] == 2  # next birth needs NEW proven edge
-    strat = (gclaw_home / "children" / state["children"][0]["name"] / "TRADING_STRATEGY.md").read_text()
+    strat = (
+        gclaw_home / "children" / state["children"][0]["name"] / "TRADING_STRATEGY.md"
+    ).read_text()
     assert "win0" in strat and "win1" in strat  # inherits the proven winners by name
 
 
@@ -108,9 +110,15 @@ def test_partial_failure_rolls_back_the_child_dir(metabolism_fixture, gclaw_home
     _meta(metabolism_fixture, goodwill=8)
     _seed_dna(gclaw_home)
     _seed_forge(gclaw_home, proven=2)
-    monkeypatch.setattr(evolve, "save_state", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("disk full")))
+    monkeypatch.setattr(
+        evolve, "save_state", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("disk full"))
+    )
     with pytest.raises(RuntimeError, match="disk full"):
         evolve.cmd_replicate(Namespace(auto=True, name=None, role=None, mutation=None))
-    assert not list((gclaw_home / "children").glob("*")) if (gclaw_home / "children").exists() else True
+    assert (
+        not list((gclaw_home / "children").glob("*"))
+        if (gclaw_home / "children").exists()
+        else True
+    )
     state = json.loads((gclaw_home / "metabolism.json").read_text(encoding="utf-8"))
     assert state["children"] == []

--- a/tests/test_forge_author.py
+++ b/tests/test_forge_author.py
@@ -24,14 +24,23 @@ def _args(tmp: Path, body: str, name: str) -> Namespace:
     f = tmp / "signal_body.py"
     f.write_text(body, encoding="utf-8")
     return Namespace(
-        name=name, signal_file=str(f), claim="test", kind="edge",
-        coin="BTC", interval="1h", limit=200, parent=None, force=False,
+        name=name,
+        signal_file=str(f),
+        claim="test",
+        kind="edge",
+        coin="BTC",
+        interval="1h",
+        limit=200,
+        parent=None,
+        force=False,
     )
 
 
 def _card(proven: bool) -> dict:
     return {
-        "proven": proven, "coin": "BTC", "interval": "1h",
+        "proven": proven,
+        "coin": "BTC",
+        "interval": "1h",
         "out_of_sample": {"n": 50, "expectancy": 0.01 if proven else -0.01},
     }
 
@@ -39,6 +48,7 @@ def _card(proven: bool) -> dict:
 def _no_execute(monkeypatch) -> None:
     def boom(_intent):
         raise AssertionError("author must NEVER execute a trade")
+
     monkeypatch.setattr(forge, "_execute", boom)
 
 

--- a/tests/test_forge_autoprove.py
+++ b/tests/test_forge_autoprove.py
@@ -15,7 +15,9 @@ import forge
 
 
 def _wire(monkeypatch, universe, bt):
-    monkeypatch.setattr(forge, "load_style", lambda: {"adopted": [{"id": "mom", "coin": "ETH", "interval": "4h"}]})
+    monkeypatch.setattr(
+        forge, "load_style", lambda: {"adopted": [{"id": "mom", "coin": "ETH", "interval": "4h"}]}
+    )
     monkeypatch.setattr(forge, "_intel_features", lambda: universe)
     monkeypatch.setattr(forge, "load_signal", lambda _tid: None)  # ignored — backtest is mocked
     monkeypatch.setattr(forge, "_backtest_with", bt)
@@ -26,7 +28,11 @@ def _card(proven, n=50, exp=0.01):
 
 
 def test_autoprove_registers_only_pairs_with_out_of_sample_edge(gclaw_home, monkeypatch):
-    universe = {"ETH": {"regime": "range"}, "xyz:MU": {"regime": "range"}, "xyz:DUST": {"regime": "range"}}
+    universe = {
+        "ETH": {"regime": "range"},
+        "xyz:MU": {"regime": "range"},
+        "xyz:DUST": {"regime": "range"},
+    }
 
     def bt(_fn, coin, _interval, _limit, _tid=None):
         return _card(coin == "xyz:MU")  # only MU has edge
@@ -56,7 +62,9 @@ def test_autoprove_cooldown_skips_a_recently_attempted_pair(gclaw_home, monkeypa
 
 
 def test_autoprove_no_intel_is_a_safe_noop(gclaw_home, monkeypatch):
-    monkeypatch.setattr(forge, "load_style", lambda: {"adopted": [{"id": "mom", "coin": "ETH", "interval": "4h"}]})
+    monkeypatch.setattr(
+        forge, "load_style", lambda: {"adopted": [{"id": "mom", "coin": "ETH", "interval": "4h"}]}
+    )
     monkeypatch.setattr(forge, "_intel_features", lambda: {})  # no scan yet
     out = forge.cmd_autoprove(Namespace(budget=10))
     assert out["ok"] and "skipped" in out
@@ -65,5 +73,7 @@ def test_autoprove_no_intel_is_a_safe_noop(gclaw_home, monkeypatch):
 def test_proven_pairs_round_trips_the_registry(gclaw_home):
     path = gclaw_home / "forge" / "proven_markets.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text('{"pairs":[{"technique":"mom","coin":"xyz:MU"}],"attempts":{}}', encoding="utf-8")
+    path.write_text(
+        '{"pairs":[{"technique":"mom","coin":"xyz:MU"}],"attempts":{}}', encoding="utf-8"
+    )
     assert forge.proven_pairs() == {("mom", "xyz:MU")}

--- a/tests/test_forge_fee_wall.py
+++ b/tests/test_forge_fee_wall.py
@@ -137,9 +137,17 @@ def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def _intent(trades: int, *, edge_real: bool = False, conf: float = 0.6) -> dict:
     """A gate-ready intent for a proven major, with a pre-stashed memory read."""
     return {
-        "technique": "t", "coin": "SOL", "side": "long", "leverage": 2, "sl_pct": 1.0,
-        "confidence": conf, "notional": 30.0, "proven": True, "regime": "range",
-        "edge_real_mem": edge_real, "edge_trades_mem": trades,
+        "technique": "t",
+        "coin": "SOL",
+        "side": "long",
+        "leverage": 2,
+        "sl_pct": 1.0,
+        "confidence": conf,
+        "notional": 30.0,
+        "proven": True,
+        "regime": "range",
+        "edge_real_mem": edge_real,
+        "edge_trades_mem": trades,
     }
 
 
@@ -167,9 +175,7 @@ def test_matured_technique_without_edge_real_is_benched(isolated_home: Path):
     """Past the bootstrap window (>=MIN_LIVE_SAMPLE trades) with no edge_real, the
     technique HAS been fairly measured and is benched — the gate stays REAL, it does not
     probe a measured non-edge forever."""
-    gated = forge._gate_intents(
-        [_intent(trades=forge.MIN_LIVE_SAMPLE, edge_real=False)], CAPS, {}
-    )
+    gated = forge._gate_intents([_intent(trades=forge.MIN_LIVE_SAMPLE, edge_real=False)], CAPS, {})
     assert gated == []
 
 

--- a/tests/test_forge_perp_margin.py
+++ b/tests/test_forge_perp_margin.py
@@ -43,8 +43,12 @@ class TestAccountUsesFreeSpotCollateral:
             forge.subprocess,
             "run",
             lambda *a, **k: _status(
-                equity=176.0, spotUsdc=176.0, buyingPower=172.0,
-                accountValue=4.0, withdrawable=0.0, positions=[{"coin": "ETH"}],
+                equity=176.0,
+                spotUsdc=176.0,
+                buyingPower=172.0,
+                accountValue=4.0,
+                withdrawable=0.0,
+                positions=[{"coin": "ETH"}],
             ),
         )
         acct = forge._account()
@@ -61,8 +65,12 @@ class TestAccountUsesFreeSpotCollateral:
             forge.subprocess,
             "run",
             lambda *a, **k: _status(
-                equity=200.0, spotUsdc=200.0, buyingPower=20.0,
-                accountValue=180.0, withdrawable=0.0, positions=[{"coin": "BTC"}],
+                equity=200.0,
+                spotUsdc=200.0,
+                buyingPower=20.0,
+                accountValue=180.0,
+                withdrawable=0.0,
+                positions=[{"coin": "BTC"}],
             ),
         )
         acct = forge._account()
@@ -88,8 +96,13 @@ class TestIntentSizesAgainstBuyingPower:
 
     def test_zero_collateral_zeroes_a_valid_major_intent(self, gclaw_home: Path) -> None:
         intent = forge._intent(
-            "t", "ETH", self._decision(), "thrive",
-            equity=176.0, cap=3, buying_power=0.0,
+            "t",
+            "ETH",
+            self._decision(),
+            "thrive",
+            equity=176.0,
+            cap=3,
+            buying_power=0.0,
             intel={"atr_pct": 1.5, "price": 1600.0},
             edge={"win_rate": 0.6, "payoff": 1.5, "trades": 40},
         )
@@ -99,8 +112,13 @@ class TestIntentSizesAgainstBuyingPower:
 
     def test_funded_collateral_sizes_a_real_major_notional(self, gclaw_home: Path) -> None:
         intent = forge._intent(
-            "t", "ETH", self._decision(), "thrive",
-            equity=176.0, cap=3, buying_power=150.0,
+            "t",
+            "ETH",
+            self._decision(),
+            "thrive",
+            equity=176.0,
+            cap=3,
+            buying_power=150.0,
             intel={"atr_pct": 1.5, "price": 1600.0},
             edge={"win_rate": 0.6, "payoff": 1.5, "trades": 40},
         )

--- a/tests/test_forge_risk_cap.py
+++ b/tests/test_forge_risk_cap.py
@@ -30,9 +30,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 import forge  # noqa: E402
 
-_FIXTURE_OK = settings(
-    suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None
-)
+_FIXTURE_OK = settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 
 
 @pytest.fixture

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -18,10 +18,38 @@ import pytest
 import outcomes
 
 SIDES = [
-    {"outcomeId": 173, "name": "Argentina", "side": "No", "coin": "#1731", "price": 0.80, "volumeUsd": 263901.0},
-    {"outcomeId": 173, "name": "Argentina", "side": "Yes", "coin": "#1730", "price": 0.20, "volumeUsd": 64944.0},
-    {"outcomeId": 999, "name": "Thin", "side": "Yes", "coin": "#9990", "price": 0.50, "volumeUsd": 500.0},
-    {"outcomeId": 888, "name": "Longshot", "side": "Yes", "coin": "#8880", "price": 0.05, "volumeUsd": 50000.0},
+    {
+        "outcomeId": 173,
+        "name": "Argentina",
+        "side": "No",
+        "coin": "#1731",
+        "price": 0.80,
+        "volumeUsd": 263901.0,
+    },
+    {
+        "outcomeId": 173,
+        "name": "Argentina",
+        "side": "Yes",
+        "coin": "#1730",
+        "price": 0.20,
+        "volumeUsd": 64944.0,
+    },
+    {
+        "outcomeId": 999,
+        "name": "Thin",
+        "side": "Yes",
+        "coin": "#9990",
+        "price": 0.50,
+        "volumeUsd": 500.0,
+    },
+    {
+        "outcomeId": 888,
+        "name": "Longshot",
+        "side": "Yes",
+        "coin": "#8880",
+        "price": 0.05,
+        "volumeUsd": 50000.0,
+    },
 ]
 
 
@@ -45,7 +73,9 @@ def test_rule_a_reject_unknown_coin() -> None:
 
 
 def test_rule_a_reject_low_volume_side_present_in_board() -> None:
-    sides = SIDES + [{"outcomeId": 7, "name": "x", "side": "y", "coin": "#70", "price": 0.5, "volumeUsd": 9000.0}]
+    sides = SIDES + [
+        {"outcomeId": 7, "name": "x", "side": "y", "coin": "#70", "price": 0.5, "volumeUsd": 9000.0}
+    ]
     v = outcomes.evaluate_bet("#70", 0.99, 5, sides, set(), 0)
     assert "volume" in v["skipped"] and "floor" in v["skipped"]
 
@@ -91,10 +121,26 @@ def test_prob_out_of_range_is_a_clean_skip() -> None:
 def test_brier_contribution_perfect_and_worst() -> None:
     # outcome=1, prob=1.0 → 0; prob=0.0 → 1. (prob - outcome)^2.
     assert (1.0 - 1) ** 2 == 0.0
-    led = {"tickets": [
-        {"price": 0.8, "prob": 0.9, "shadow": True, "resolved": True, "outcome": 1, "brier": (0.9 - 1) ** 2},
-        {"price": 0.3, "prob": 0.4, "shadow": True, "resolved": True, "outcome": 0, "brier": (0.4 - 0) ** 2},
-    ]}
+    led = {
+        "tickets": [
+            {
+                "price": 0.8,
+                "prob": 0.9,
+                "shadow": True,
+                "resolved": True,
+                "outcome": 1,
+                "brier": (0.9 - 1) ** 2,
+            },
+            {
+                "price": 0.3,
+                "prob": 0.4,
+                "shadow": True,
+                "resolved": True,
+                "outcome": 0,
+                "brier": (0.4 - 0) ** 2,
+            },
+        ]
+    }
     agg = outcomes._aggregate(led["tickets"])
     assert agg["n_resolved"] == 2
     assert agg["brier_mean"] == pytest.approx(((0.1**2) + (0.4**2)) / 2)
@@ -171,13 +217,39 @@ def test_gate_rejection_records_nothing(gclaw_home: Path, monkeypatch) -> None:
 _OLD_TS = "2026-01-01T00:00:00+00:00"
 
 
-def test_resolve_scores_brier_from_settlement_fills_calibration_only(gclaw_home: Path, monkeypatch) -> None:
-    led = {"tickets": [
-        {"coin": "#1731", "outcomeId": 173, "name": "Argentina", "side": "No", "prob": 0.9,
-         "price": 0.8, "stake": 8.0, "edge": 0.1, "shadow": True, "resolved": False, "ts": _OLD_TS},
-        {"coin": "#8880", "outcomeId": 888, "name": "L", "side": "Yes", "prob": 0.7,
-         "price": 0.5, "stake": 8.0, "edge": 0.2, "shadow": False, "resolved": False, "ts": _OLD_TS},
-    ]}
+def test_resolve_scores_brier_from_settlement_fills_calibration_only(
+    gclaw_home: Path, monkeypatch
+) -> None:
+    led = {
+        "tickets": [
+            {
+                "coin": "#1731",
+                "outcomeId": 173,
+                "name": "Argentina",
+                "side": "No",
+                "prob": 0.9,
+                "price": 0.8,
+                "stake": 8.0,
+                "edge": 0.1,
+                "shadow": True,
+                "resolved": False,
+                "ts": _OLD_TS,
+            },
+            {
+                "coin": "#8880",
+                "outcomeId": 888,
+                "name": "L",
+                "side": "Yes",
+                "prob": 0.7,
+                "price": 0.5,
+                "stake": 8.0,
+                "edge": 0.2,
+                "shadow": False,
+                "resolved": False,
+                "ts": _OLD_TS,
+            },
+        ]
+    }
     outcomes.save_ledger(led)
     # Real HL settlement fills: #1731 settled TRUE (px 1), #8880 settled FALSE (px 0).
     settlements = [
@@ -187,8 +259,11 @@ def test_resolve_scores_brier_from_settlement_fills_calibration_only(gclaw_home:
     monkeypatch.setattr(outcomes, "fetch_settlements", lambda: settlements)
     # The desk must NEVER settle PnL itself — autosettle owns it. Catch any subprocess
     # (a metabolism settle) as a double-count regression.
-    monkeypatch.setattr(outcomes.subprocess, "run",
-                        lambda *a, **k: pytest.fail("cmd_resolve must not settle PnL (autosettle owns it)"))
+    monkeypatch.setattr(
+        outcomes.subprocess,
+        "run",
+        lambda *a, **k: pytest.fail("cmd_resolve must not settle PnL (autosettle owns it)"),
+    )
     res = outcomes.cmd_resolve(argparse.Namespace())
     assert res["resolved"] == 2
     final = json.loads((gclaw_home / "calibration.json").read_text())
@@ -200,10 +275,23 @@ def test_resolve_scores_brier_from_settlement_fills_calibration_only(gclaw_home:
 
 
 def test_resolve_is_idempotent(gclaw_home: Path, monkeypatch) -> None:
-    led = {"tickets": [
-        {"coin": "#1731", "outcomeId": 173, "name": "A", "side": "No", "prob": 0.9, "price": 0.8,
-         "stake": 8.0, "edge": 0.1, "shadow": False, "resolved": False, "ts": _OLD_TS},
-    ]}
+    led = {
+        "tickets": [
+            {
+                "coin": "#1731",
+                "outcomeId": 173,
+                "name": "A",
+                "side": "No",
+                "prob": 0.9,
+                "price": 0.8,
+                "stake": 8.0,
+                "edge": 0.1,
+                "shadow": False,
+                "resolved": False,
+                "ts": _OLD_TS,
+            },
+        ]
+    }
     outcomes.save_ledger(led)
     settlements = [{"coin": "#1731", "settlePx": 1.0, "closedPnl": 2.0, "time": 9.0e12}]
     monkeypatch.setattr(outcomes, "fetch_settlements", lambda: settlements)
@@ -214,12 +302,27 @@ def test_resolve_is_idempotent(gclaw_home: Path, monkeypatch) -> None:
 
 def test_resolve_ignores_settlement_predating_the_ticket(gclaw_home: Path, monkeypatch) -> None:
     # A settlement that happened BEFORE the bet must not resolve it (stale-coin guard).
-    led = {"tickets": [
-        {"coin": "#1731", "outcomeId": 173, "name": "A", "side": "No", "prob": 0.9, "price": 0.8,
-         "stake": 8.0, "edge": 0.1, "shadow": True, "resolved": False, "ts": "2026-06-01T00:00:00+00:00"},
-    ]}
+    led = {
+        "tickets": [
+            {
+                "coin": "#1731",
+                "outcomeId": 173,
+                "name": "A",
+                "side": "No",
+                "prob": 0.9,
+                "price": 0.8,
+                "stake": 8.0,
+                "edge": 0.1,
+                "shadow": True,
+                "resolved": False,
+                "ts": "2026-06-01T00:00:00+00:00",
+            },
+        ]
+    }
     outcomes.save_ledger(led)
-    settlements = [{"coin": "#1731", "settlePx": 1.0, "closedPnl": 2.0, "time": 1.0e12}]  # ~2001, pre-bet
+    settlements = [
+        {"coin": "#1731", "settlePx": 1.0, "closedPnl": 2.0, "time": 1.0e12}
+    ]  # ~2001, pre-bet
     monkeypatch.setattr(outcomes, "fetch_settlements", lambda: settlements)
     res = outcomes.cmd_resolve(argparse.Namespace())
     assert res["resolved"] == 0
@@ -233,18 +336,38 @@ def test_calibration_read_never_raises_on_empty(gclaw_home: Path) -> None:
 # ── Edgeable partition + honest no-edgeable-market skip ───────────────────────
 
 _CRYPTO_SIDE = {
-    "outcomeId": 713, "name": "Recurring", "side": "Yes", "coin": "#7130",
-    "price": 0.75, "volumeUsd": 188506.0, "category": "crypto-price",
-    "resolution": {"underlying": "BTC", "targetPrice": 59122, "expiry": "20260702-0600", "period": "1d"},
+    "outcomeId": 713,
+    "name": "Recurring",
+    "side": "Yes",
+    "coin": "#7130",
+    "price": 0.75,
+    "volumeUsd": 188506.0,
+    "category": "crypto-price",
+    "resolution": {
+        "underlying": "BTC",
+        "targetPrice": 59122,
+        "expiry": "20260702-0600",
+        "period": "1d",
+    },
 }
 _MACRO_SIDE = {
-    "outcomeId": 510, "name": "No change", "side": "Yes", "coin": "#5100",
-    "price": 0.6, "volumeUsd": 40000.0, "category": "macro",
+    "outcomeId": 510,
+    "name": "No change",
+    "side": "Yes",
+    "coin": "#5100",
+    "price": 0.6,
+    "volumeUsd": 40000.0,
+    "category": "macro",
     "description": "resolves to Yes if the July 2026 FOMC decision leaves the rate unchanged",
 }
 _SPORTS_SIDE = {
-    "outcomeId": 173, "name": "Argentina", "side": "No", "coin": "#1731",
-    "price": 0.81, "volumeUsd": 287125.0, "category": "sports",
+    "outcomeId": 173,
+    "name": "Argentina",
+    "side": "No",
+    "coin": "#1731",
+    "price": 0.81,
+    "volumeUsd": 287125.0,
+    "category": "sports",
     "description": "resolves to Yes if Argentina is the 2026 FIFA World Cup champion",
 }
 
@@ -257,12 +380,16 @@ def test_partition_splits_crypto_and_macro_from_sports() -> None:
 
 def test_partition_treats_uncategorized_side_as_efficient() -> None:
     # Fail closed: a side with no category (older bridge output) is never called edgeable.
-    edgeable, efficient = outcomes.partition_edgeable([{"coin": "#x", "price": 0.5, "volumeUsd": 99999.0}])
+    edgeable, efficient = outcomes.partition_edgeable(
+        [{"coin": "#x", "price": 0.5, "volumeUsd": 99999.0}]
+    )
     assert edgeable == [] and len(efficient) == 1
 
 
 def test_markets_surfaces_edgeable_crypto_market(monkeypatch) -> None:
-    monkeypatch.setattr(outcomes, "fetch_sides", lambda min_vol=outcomes.MIN_VOLUME: [_SPORTS_SIDE, _CRYPTO_SIDE])
+    monkeypatch.setattr(
+        outcomes, "fetch_sides", lambda min_vol=outcomes.MIN_VOLUME: [_SPORTS_SIDE, _CRYPTO_SIDE]
+    )
     out = outcomes.cmd_markets(argparse.Namespace(min_vol=None))
     assert out["ok"] and out["edgeable_count"] == 1
     assert out["edgeable"][0]["coin"] == "#7130"
@@ -283,5 +410,7 @@ def test_gate_still_refuses_no_edge_sports_side() -> None:
     # Surfacing the broader set must NOT weaken the gate: an efficient sports side where the
     # LLM's probability does not diverge past the margin is still cleanly skipped.
     sides = [_SPORTS_SIDE]
-    v = outcomes.evaluate_bet("#1731", prob=0.83, stake=8.0, sides=sides, open_coins=set(), n_open=0)
+    v = outcomes.evaluate_bet(
+        "#1731", prob=0.83, stake=8.0, sides=sides, open_coins=set(), n_open=0
+    )
     assert v["placed"] is False and "margin" in v["skipped"]

--- a/tests/test_reputation.py
+++ b/tests/test_reputation.py
@@ -14,29 +14,52 @@ AID = "55624"
 
 
 def _seed(home: Path, adopted: list[dict], authored: list[str]) -> None:
-    (home / "metabolism.json").write_text(json.dumps({
-        "born_at": "2026-06-17T00:00:00+00:00", "heartbeats": 346, "recodes": 4,
-        "children": [{"name": "scion-1"}],
-        "onchain_identity": {"agentId": AID, "chain": "base:8453", "registry": "0xReg", "agentUrl": "u"},
-    }), encoding="utf-8")
+    (home / "metabolism.json").write_text(
+        json.dumps(
+            {
+                "born_at": "2026-06-17T00:00:00+00:00",
+                "heartbeats": 346,
+                "recodes": 4,
+                "children": [{"name": "scion-1"}],
+                "onchain_identity": {
+                    "agentId": AID,
+                    "chain": "base:8453",
+                    "registry": "0xReg",
+                    "agentUrl": "u",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
     techs = home / "forge" / "techniques"
     techs.mkdir(parents=True, exist_ok=True)
     (home / "forge" / "style.json").write_text(json.dumps({"adopted": adopted}), encoding="utf-8")
     for tid in authored:
         (techs / tid).mkdir(parents=True, exist_ok=True)
-        (techs / tid / "technique.json").write_text(json.dumps({"id": tid, "author": AID}), encoding="utf-8")
+        (techs / tid / "technique.json").write_text(
+            json.dumps({"id": tid, "author": AID}), encoding="utf-8"
+        )
 
 
 def test_card_is_backed_by_settled_performance(gclaw_home, monkeypatch):
-    monkeypatch.setattr(reputation, "_economics", lambda: {
-        "n": 52, "win_rate": 0.19, "avg_win": 1.2, "avg_loss": -1.23, "net": -39.82, "expectancy": -0.77,
-    })
+    monkeypatch.setattr(
+        reputation,
+        "_economics",
+        lambda: {
+            "n": 52,
+            "win_rate": 0.19,
+            "avg_win": 1.2,
+            "avg_loss": -1.23,
+            "net": -39.82,
+            "expectancy": -0.77,
+        },
+    )
     _seed(
         gclaw_home,
         adopted=[
-            {"id": "stop-hunt-revert", "e": 0.16, "trades": 9},   # proven (seed author)
-            {"id": "vol-momentum", "e": 0.05, "trades": 5},        # proven + self-authored
-            {"id": "weak", "e": -0.01, "trades": 8},               # adopted but not proven
+            {"id": "stop-hunt-revert", "e": 0.16, "trades": 9},  # proven (seed author)
+            {"id": "vol-momentum", "e": 0.05, "trades": 5},  # proven + self-authored
+            {"id": "weak", "e": -0.01, "trades": 8},  # adopted but not proven
         ],
         authored=["vol-momentum"],  # only this one is author==AID
     )


### PR DESCRIPTION
Every ci run was failing. **node job:** scripts required ethers+SDK at top-level → tests crashed on import; fixed by loading them tolerantly (pure-tested files) / local-first (predict.js) + adding ethers to devDeps. **python job:** `uv run --no-project ruff` couldn't spawn ruff → switched to `uvx ruff@0.15.13`; and 16 files were never `ruff format`-ted → formatted them. Verified locally with the SDK absent: vitest 301, ruff format+check clean, pytest 333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)