### PR TITLE
Live-proven edge honesty + pytest CVE fix (v4.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img alt="GEMACH" src="assets/brand/gemach-lockup-black-on-light.png" width="260">
 </picture>
 
-<sub>`// GEMACH ECOSYSTEM · SELF-EVOLVING TRADING AGENT · v4.0.0`</sub>
+<sub>`// GEMACH ECOSYSTEM · SELF-EVOLVING TRADING AGENT · v4.1.0`</sub>
 
 # GCLAW
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not — scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.13"
 #    adversarially and shrinks any counterexample to a minimal repro. Dev-only, never shipped.
 #  * mutmut     — mutation testing. Proves the property suite actually FAILS when the math
 #    is broken; a green suite that survives mutants is false confidence.
-dev = ["pytest==8.4.2", "hypothesis==6.155.6", "mutmut==3.6.0"]
+dev = ["pytest==9.1.1", "hypothesis==6.155.6", "mutmut==3.6.0"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -40,7 +40,6 @@ from typing import Any
 IDENTITY_REGISTRY = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432"  # ERC-8004 on Base
 GITHUB_URL = "https://github.com/GemachDAO/Gclaw"
 SCRIPT_DIR = Path(__file__).resolve().parent
-PROVEN_MIN_TRADES = 3  # a technique is live-proven at >= this many closes w/ positive e
 REPLICATE_MIN_EDGE = 2  # proven-edge techniques required to breed (mirrors evolve.py)
 
 
@@ -598,14 +597,19 @@ def _svg_inline(p: Path) -> str:
 # Pure data-shaping — small functions that turn the state dict into the exact
 # values each render section needs. No I/O; unit-testable.
 # --------------------------------------------------------------------------- #
-def proven_edge(style: dict[str, Any]) -> list[dict[str, Any]]:
-    """Adopted techniques with REAL live edge (>= PROVEN_MIN_TRADES closes, positive
-    expectancy) — the inheritable DNA the fitness signal counts (mirrors evolve.py)."""
-    return [
-        e
-        for e in style.get("adopted", [])
-        if int(e.get("trades", 0) or 0) >= PROVEN_MIN_TRADES and float(e.get("e", 0.0) or 0) > 0
-    ]
+def live_proven_ids(state: dict[str, Any]) -> set[str]:
+    """The LIVE-proven technique ids from the reputation scorecard — the single source of
+    truth (memory.py bootstrap-CI ``edge_real`` via reputation.py), NOT style.json's loose
+    EWMA fitness counter. Keeps the helix, the breed gate, and evolve.py in agreement."""
+    evo = (state.get("reputation") or {}).get("evolution") or {}
+    return set(evo.get("proven_edge_techniques") or [])
+
+
+def proven_edge(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Adopted techniques with REAL live edge (bootstrap CI > 0 over settled fills) — the
+    inheritable DNA the reproduction gate breeds on (mirrors evolve.py, same source)."""
+    proven_ids = live_proven_ids(state)
+    return [e for e in state.get("style", {}).get("adopted", []) if e.get("id") in proven_ids]
 
 
 def breed_gate(state: dict[str, Any], proven: list[dict[str, Any]]) -> dict[str, Any]:
@@ -686,21 +690,22 @@ def author_events(state: dict[str, Any], limit: int = 8) -> list[dict[str, Any]]
     return events
 
 
-def proven_dna(style: dict[str, Any]) -> list[dict[str, Any]]:
-    """Every adopted technique as a base pair for the helix — id, live expectancy,
-    trades, weight, and whether it is proven. Fed to the 3D strand as real DNA."""
+def proven_dna(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every adopted technique as a base pair for the helix — id, fitness expectancy,
+    trades, weight, and whether it is LIVE-proven. The ``e``/``trades``/``weight`` shown
+    are the style.json fitness signal; the ``proven`` flag comes from the strict live-edge
+    set (reputation scorecard), so the helix can't badge an unproven technique as proven."""
+    proven_ids = live_proven_ids(state)
     out = []
-    for e in style.get("adopted", []):
+    for e in state.get("style", {}).get("adopted", []):
         tid = e.get("id") if isinstance(e, dict) else e
-        exp = float(e.get("e", 0.0) or 0.0)
-        trades = int(e.get("trades", 0) or 0)
         out.append(
             {
                 "id": tid,
-                "e": round(exp, 4),
-                "trades": trades,
+                "e": round(float(e.get("e", 0.0) or 0.0), 4),
+                "trades": int(e.get("trades", 0) or 0),
                 "weight": round(float(e.get("weight", 1.0) or 1.0), 3),
-                "proven": trades >= PROVEN_MIN_TRADES and exp > 0,
+                "proven": tid in proven_ids,
             }
         )
     return out
@@ -1071,7 +1076,7 @@ def techniques_html(state: dict[str, Any]) -> str:
     adopted = state["style"].get("adopted", [])
     if not adopted:
         return el("p", "No techniques yet — the arsenal is installed at birth.", cls="muted")
-    proven_ids = {p["id"] for p in proven_edge(state["style"])}
+    proven_ids = {p["id"] for p in proven_edge(state)}
     rows = []
     for e in sorted(adopted, key=lambda x: -float(x.get("weight", 1.0) or 1.0)):
         tid = str(e.get("id"))
@@ -1287,7 +1292,7 @@ def dna_script(state: dict[str, Any], proven: list[dict[str, Any]]) -> str:
     """The 3D proven-DNA strand + the lineage graph + the shareable card data — all
     fed REAL proven-edge DNA (not a hash). Reuses the existing Three.js engine."""
     g = state["genome"]
-    dna = proven_dna(state["style"])
+    dna = proven_dna(state)
     active = len(state["positions"].get("positions") or []) > 0
     graph = lineage_graph(state, proven)
     persona = state["persona"] or {}
@@ -1642,7 +1647,7 @@ def render(state: dict[str, Any]) -> str:
     """
     g = state["genome"]
     name = state["metabolism"].get("name") or g["species"]
-    proven = proven_edge(state["style"])
+    proven = proven_edge(state)
     gate = breed_gate(state, proven)
 
     glance = hero_html(state, proven, gate) + vitals_html(state, gate) + track_record_html(state)

--- a/scripts/evolve.py
+++ b/scripts/evolve.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import shutil
+import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -30,7 +31,9 @@ from typing import Any
 # luck. "Recode" likewise becomes honest: self-modification = authoring a technique that
 # graduated, not a hand-edit counter.
 REPLICATE_MIN_EDGE = int(os.environ.get("GCLAW_REPLICATE_MIN_EDGE") or 2)
-PROVEN_MIN_TRADES = 3  # a technique is live-proven at >= this many closes with positive edge
+# The "live-proven" bar (bootstrap CI > 0 over >= 3 settled closes) is defined once in
+# memory.py (LIVE_PROVEN_MIN_TRADES) and read here via `memory.py techniques`, so the
+# reproduction gate and the reputation scorecard can never drift apart.
 SWARM_THRESHOLD = 200  # swarm coordination stays goodwill-gated (out of P4 scope)
 MAX_CHILDREN = 8
 
@@ -49,14 +52,33 @@ def _adopted() -> list[dict[str, Any]]:
         return []
 
 
+def _live_proven_ids() -> set[str]:
+    """LIVE-proven technique ids from settled fills — delegates to memory.py so the
+    bootstrap-CI ``edge_real`` gate lives in exactly one place. Empty on any failure
+    (fail closed: no verifiable edge → no reproduction)."""
+    script_dir = Path(__file__).resolve().parent
+    try:
+        out = subprocess.run(
+            ["uv", "run", "--no-project", "python3", str(script_dir / "memory.py"), "techniques"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        ).stdout
+        i = out.find("{")
+        rows = (json.loads(out[i:]) if i >= 0 else {}).get("techniques", [])
+        return {r["technique"] for r in rows if r.get("live_proven")}
+    except (subprocess.SubprocessError, ValueError, OSError, KeyError):
+        return set()
+
+
 def proven_edge_techniques() -> list[dict[str, Any]]:
-    """Adopted techniques with REAL live edge (>= PROVEN_MIN_TRADES closes, positive
-    expectancy) — the inheritable DNA reproduction gates on (the fitness Spore.fun lacked)."""
-    return [
-        e
-        for e in _adopted()
-        if int(e.get("trades", 0)) >= PROVEN_MIN_TRADES and float(e.get("e", 0.0)) > 0
-    ]
+    """Adopted techniques with REAL live edge (bootstrap CI > 0 over the settled fills) —
+    the inheritable DNA reproduction gates on (the fitness Spore.fun lacked). Uses the same
+    non-fakeable memory.py signal as reputation.py, NOT the loose EWMA fitness counter in
+    style.json, which can read positive from recency alone while the record is a net loss."""
+    proven = _live_proven_ids()
+    return [e for e in _adopted() if e.get("id") in proven]
 
 
 def self_authored_adopted(state: dict[str, Any]) -> list[str]:

--- a/scripts/memory.py
+++ b/scripts/memory.py
@@ -17,6 +17,7 @@ transparent: one JSONL line per trade at $GCLAW_HOME/memory.jsonl.
     memory.py expectancy --technique stock-meanrev [--regime range]
     memory.py query --regime range          # rank techniques for this regime
     memory.py summary                        # per (technique,regime) table (for the swarm)
+    memory.py techniques                     # per-technique LIVE edge + live_proven flag
 """
 
 from __future__ import annotations
@@ -42,6 +43,13 @@ def load() -> list[dict]:
     if not p.exists():
         return []
     return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+# A technique is LIVE-proven only with a real bootstrap edge over at least this many
+# settled closes. `edge_real` (CI lower bound > 0) already requires >= 3 samples, so
+# this is the same floor stated explicitly — the one honest bar reputation.py and
+# evolve.py both gate on, in place of the loose EWMA fitness counter in style.json.
+LIVE_PROVEN_MIN_TRADES = 3
 
 
 def _read_json(path: Path, default):
@@ -216,6 +224,36 @@ def summary(_args: argparse.Namespace) -> dict:
     return {"ok": True, "table": table}
 
 
+def techniques(_args: argparse.Namespace) -> dict:
+    """Per-technique LIVE edge pooled across all regimes — the honest 'is it proven?' table.
+
+    Pools every settled close for a technique (regime-agnostic) and runs the same
+    bootstrap-CI ``edge_real`` gate the forge trusts for sizing. ``live_proven`` is True
+    only when the whole 95% CI sits above zero on >= LIVE_PROVEN_MIN_TRADES closes — the
+    non-fakeable signal reputation.py and evolve.py gate on, instead of the loose EWMA
+    fitness counter in style.json (which overstates edge from recency alone).
+    """
+    by_tech: dict[str, list[dict]] = {}
+    for row in load():
+        by_tech.setdefault(row.get("technique", "?"), []).append(row)
+    out = []
+    for t, rs in by_tech.items():
+        s = _stats(rs)
+        out.append(
+            {
+                "technique": t,
+                "trades": s["trades"],
+                "expectancy_r": s.get("expectancy_r", 0.0),
+                "pnl_usd": s.get("pnl_usd", 0.0),
+                "edge_real": s.get("edge_real", False),
+                "live_proven": bool(s.get("edge_real"))
+                and s["trades"] >= LIVE_PROVEN_MIN_TRADES,
+            }
+        )
+    out.sort(key=lambda e: (e["live_proven"], e["expectancy_r"]), reverse=True)
+    return {"ok": True, "techniques": out}
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description="trade-memory + regime-conditional expectancy")
     sub = p.add_subparsers(dest="command", required=True)
@@ -232,6 +270,7 @@ def main() -> int:
     q = sub.add_parser("query")
     q.add_argument("--regime", required=True)
     sub.add_parser("summary")
+    sub.add_parser("techniques")
     sub.add_parser("swarm")
     args = p.parse_args()
     fn = {
@@ -239,6 +278,7 @@ def main() -> int:
         "expectancy": expectancy,
         "query": query,
         "summary": summary,
+        "techniques": techniques,
         "swarm": swarm,
     }[args.command]
     print(json.dumps(fn(args), indent=2))

--- a/scripts/reputation.py
+++ b/scripts/reputation.py
@@ -4,9 +4,13 @@
 gclaw's onchain ERC-8004 reputation is backed by SETTLED, VERIFIABLE performance — not
 social activity. Almost every other agent's "reputation" is posts and followers; this one
 is derived only from non-fakeable data: realized PnL from settled HyperLiquid fills (booked
-by autosettle), forge-graduated live-edge techniques, honest self-modification counts, and
-lineage. Anyone can re-derive every number from the managed address's onchain fills + the
-public forge state, which is exactly the point.
+by autosettle), honest self-modification counts, and lineage. Anyone can re-derive every
+number from the managed address's onchain fills + the public forge state.
+
+Edge is reported at two honesty tiers so the headline can't overstate: ``proven_edge`` counts
+only LIVE-proven techniques (bootstrap CI above zero over real settled fills, via memory.py),
+while ``backtest_proven`` counts techniques that merely graduated the walk-forward backtest and
+have not yet earned a live edge. The onchain attestation reads the strict LIVE number.
 
     reputation.py card      # print the scorecard JSON
     reputation.py publish    # write it atomically to $GCLAW_HOME/reputation.json
@@ -63,8 +67,47 @@ def _economics() -> dict[str, Any]:
         return {}
 
 
-def _proven_edge(adopted: list[dict[str, Any]]) -> list[str]:
-    return [e["id"] for e in adopted if int(e.get("trades", 0)) >= 3 and float(e.get("e", 0.0)) > 0]
+def _live_techniques() -> dict[str, dict[str, Any]]:
+    """Per-technique LIVE edge from settled fills — the honest, non-fakeable record.
+
+    Delegates to memory.py so the bootstrap-CI ``edge_real`` gate is defined in exactly
+    one place. Returns a {technique_id: stats} map; empty on any failure (fail closed —
+    an unreadable record proves no edge).
+    """
+    try:
+        out = subprocess.run(
+            ["uv", "run", "--no-project", "python3", str(SCRIPT_DIR / "memory.py"), "techniques"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        ).stdout
+        i = out.find("{")
+        rows = (json.loads(out[i:]) if i >= 0 else {}).get("techniques", [])
+        return {r["technique"]: r for r in rows}
+    except (subprocess.SubprocessError, ValueError, OSError, KeyError):
+        return {}
+
+
+def _live_proven(adopted: list[dict[str, Any]], live: dict[str, dict[str, Any]]) -> list[str]:
+    """Adopted techniques with a REAL live edge from settled fills (bootstrap CI > 0).
+
+    This is what the onchain scorecard attests — not the loose EWMA fitness counter in
+    style.json, which can read positive from recency alone while the settled record is
+    negative (e.g. a technique with 9 fitness ticks but no statistically-real edge).
+    """
+    return [e["id"] for e in adopted if live.get(e["id"], {}).get("live_proven")]
+
+
+def _backtest_proven(adopted: list[dict[str, Any]]) -> list[str]:
+    """Adopted techniques that graduated the walk-forward backtest (technique.json
+    status == 'proven') — earned on historical candles, NOT yet confirmed by real fills."""
+    out: list[str] = []
+    for e in adopted:
+        tech = _read_json(home() / "forge" / "techniques" / e["id"] / "technique.json", {})
+        if str(tech.get("status")) == "proven":
+            out.append(e["id"])
+    return out
 
 
 def _self_authored(adopted: list[dict[str, Any]], agent_id: str) -> list[str]:
@@ -84,7 +127,9 @@ def card() -> dict[str, Any]:
     econ = _economics()
     adopted = (_read_json(home() / "forge" / "style.json", {}) or {}).get("adopted", [])
     calib = (_read_json(home() / "calibration.json", {}) or {}).get("aggregates", {})
-    proven = _proven_edge(adopted)
+    live = _live_techniques()
+    proven = _live_proven(adopted, live)
+    backtest_proven = _backtest_proven(adopted)
     return {
         "agentId": agent_id,
         "born_at": meta.get("born_at"),
@@ -101,6 +146,8 @@ def card() -> dict[str, Any]:
             "self_authored_techniques": len(_self_authored(adopted, agent_id)),
             "proven_edge_techniques": proven,
             "proven_edge_count": len(proven),
+            "backtest_proven_techniques": backtest_proven,
+            "backtest_proven_count": len(backtest_proven),
             "recodes": meta.get("recodes", 0),
             "children": len(meta.get("children", [])),
         },
@@ -110,8 +157,10 @@ def card() -> dict[str, Any]:
             "no_skill_baseline": calib.get("baseline_mean"),
         },
         "accountability": (
-            "reputation derived from SETTLED HyperLiquid fills + forge graduation — not social "
-            "activity; every figure is re-derivable from the managed address's onchain fills."
+            "reputation derived from SETTLED HyperLiquid fills — not social activity. "
+            "proven_edge = LIVE-proven (bootstrap CI > 0 on real fills); backtest_proven = "
+            "graduated on historical candles but NOT yet confirmed live. Every figure is "
+            "re-derivable from the managed address's onchain fills + the public forge state."
         ),
         "verifiable_via": {
             "chain": ident.get("chain"),

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -40,15 +40,15 @@ function nodeRun(script, args) {
   } catch { return null; }
 }
 
-// A technique is LIVE-PROVEN at >= 3 real closes with positive expectancy — the same
-// gate reputation.py/_proven_edge and evolve.py.proven_edge_techniques enforce. Kept in
-// sync deliberately: the manifest is the published mirror of the reputation scorecard.
-const PROVEN_MIN_TRADES = 3;
 const REPLICATE_MIN_EDGE = Number(process.env.GCLAW_REPLICATE_MIN_EDGE) || 2;
 
-function provenEdgeTechniques(adopted) {
+// The published manifest is a MIRROR of the reputation scorecard — never a second,
+// looser computation. LIVE-proven membership comes from reputation.json's
+// proven_edge_techniques (memory.py bootstrap-CI gate); the e/trades shown are the
+// style.json fitness signal for display only. Read the honest set, don't recompute it.
+function provenEdgeTechniques(adopted, provenIds) {
   return adopted
-    .filter((a) => Number(a.trades || 0) >= PROVEN_MIN_TRADES && Number(a.e || 0) > 0)
+    .filter((a) => provenIds.has(String(a.id)))
     .map((a) => ({ id: a.id, e: round(a.e), trades: Number(a.trades || 0) }));
 }
 
@@ -78,8 +78,10 @@ function buildManifest() {
   const rep = readJson(path.join(GCLAW_HOME, 'reputation.json'), {});
   const trade = rep.trading || {};
   const calib = rep.event_calibration || {};
-  const provenTechniques = provenEdgeTechniques(adopted);
-  const provenEdge = provenTechniques.length;
+  const evo = rep.evolution || {};
+  const provenIds = new Set(evo.proven_edge_techniques || []);
+  const provenTechniques = provenEdgeTechniques(adopted, provenIds);
+  const provenEdge = Number(evo.proven_edge_count ?? provenTechniques.length);
   const authored = authoredCount(adopted, id);
   const realizedPnl = round(trade.realized_pnl_usd);
   // Breed-ready mirrors evolve.py.replication_gate: >= REPLICATE_MIN_EDGE proven-edge

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,7 +40,11 @@ def _state(**overrides: object) -> dict[str, object]:
             },
             "evolution": {
                 "self_authored_techniques": 6,
+                # LIVE-proven set (bootstrap CI > 0 on settled fills) — the single source
+                # of truth the dashboard reads, not style.json's loose EWMA counter.
+                "proven_edge_techniques": ["stop-hunt-revert", "stock-meanrev"],
                 "proven_edge_count": 2,
+                "backtest_proven_count": 3,
                 "children": 0,
             },
             "event_calibration": {"n": 0, "brier": None, "no_skill_baseline": None},
@@ -118,9 +122,10 @@ def test_hero_is_proven_edge_not_goodwill_or_equity():
 
 
 def test_proven_edge_counts_only_live_proven_techniques():
-    proven = dashboard.proven_edge(_state()["style"])
+    proven = dashboard.proven_edge(_state())
     ids = {p["id"] for p in proven}
-    assert ids == {"stop-hunt-revert", "stock-meanrev"}  # vol-momentum is -EV, excluded
+    # Only the reputation scorecard's LIVE-proven set counts — vol-momentum is excluded.
+    assert ids == {"stop-hunt-revert", "stock-meanrev"}
 
 
 def test_hero_shows_the_proven_count():
@@ -165,7 +170,7 @@ def test_track_record_falls_back_to_journal_settles():
 
 
 def test_breed_gate_reflects_the_real_reproduction_rule():
-    proven = dashboard.proven_edge(_state()["style"])
+    proven = dashboard.proven_edge(_state())
     gate = dashboard.breed_gate(_state(), proven)
     assert gate["proven"] == 2
     assert gate["have_edges"] is True
@@ -177,7 +182,7 @@ def test_breed_gate_reflects_the_real_reproduction_rule():
 def test_breed_gate_locks_without_a_new_edge_since_last_birth():
     state = _state()
     state["metabolism"]["last_replicate_edge_count"] = 2
-    proven = dashboard.proven_edge(state["style"])
+    proven = dashboard.proven_edge(state)
     gate = dashboard.breed_gate(state, proven)
     assert gate["have_new"] is False
     assert gate["ready"] is False
@@ -186,7 +191,8 @@ def test_breed_gate_locks_without_a_new_edge_since_last_birth():
 def test_breed_gate_locks_below_min_edges():
     state = _state()
     state["style"] = {"adopted": [{"id": "a", "e": 0.1, "trades": 5}]}  # only 1 proven
-    proven = dashboard.proven_edge(state["style"])
+    state["reputation"]["evolution"]["proven_edge_techniques"] = ["a"]  # only 1 live-proven
+    proven = dashboard.proven_edge(state)
     gate = dashboard.breed_gate(state, proven)
     assert gate["proven"] == 1
     assert gate["have_edges"] is False
@@ -208,14 +214,14 @@ def test_calibration_renders_brier_when_present():
 
 
 def test_proven_dna_marks_proven_and_bleeding_pairs():
-    dna = dashboard.proven_dna(_state()["style"])
+    dna = dashboard.proven_dna(_state())
     by_id = {d["id"]: d for d in dna}
-    assert by_id["stop-hunt-revert"]["proven"] is True
-    assert by_id["vol-momentum"]["proven"] is False  # negative expectancy
+    assert by_id["stop-hunt-revert"]["proven"] is True  # in the live-proven set
+    assert by_id["vol-momentum"]["proven"] is False  # not live-proven
 
 
 def test_lineage_graph_buckets_by_stage():
-    graph = dashboard.lineage_graph(_state(), dashboard.proven_edge(_state()["style"]))
+    graph = dashboard.lineage_graph(_state(), dashboard.proven_edge(_state()))
     # only proven techniques land in PROVEN; inherited is empty (no children yet)
     assert any(p["id"] == "stop-hunt-revert" for p in graph["proven"])
     assert graph["inherited"] == []

--- a/tests/test_evolve.py
+++ b/tests/test_evolve.py
@@ -21,9 +21,22 @@ def _seed_dna(home):
     (dna / "TRADING_STRATEGY.md").write_text("# Strategy\n\nBase rules.\n", encoding="utf-8")
 
 
+def _live_from_style(home):
+    """Fake for evolve._live_proven_ids: treat every adopted ``win*`` technique as
+    LIVE-proven, re-reading style.json each call so mid-test re-seeds take effect. Stands
+    in for the memory.py bootstrap-CI boundary (exercised directly in test_memory.py)."""
+
+    def _inner():
+        style = json.loads((home / "forge" / "style.json").read_text(encoding="utf-8"))
+        return {e["id"] for e in style.get("adopted", []) if str(e["id"]).startswith("win")}
+
+    return _inner
+
+
 def _seed_forge(home, proven: int, authored: int = 0):
-    """Write a forge/style.json with `proven` live-proven techniques (e>0, trades>=3) and
-    `authored` self-authored technique.json files (author == AID)."""
+    """Write a forge/style.json with `proven` LIVE-proven techniques (named ``win*``, made
+    live-proven by _live_from_style) and `authored` self-authored technique.json files
+    (author == AID)."""
     techs = home / "forge" / "techniques"
     techs.mkdir(parents=True, exist_ok=True)
     adopted = []
@@ -49,6 +62,7 @@ def test_locked_without_enough_proven_edge(metabolism_fixture, gclaw_home, monke
     _meta(metabolism_fixture, goodwill=5)  # goodwill is now irrelevant
     _seed_dna(gclaw_home)
     _seed_forge(gclaw_home, proven=1)  # below REPLICATE_MIN_EDGE (2)
+    monkeypatch.setattr(evolve, "_live_proven_ids", _live_from_style(gclaw_home))
     with pytest.raises(SystemExit, match="proven-edge"):
         evolve.cmd_replicate(Namespace(auto=False, name="early", role="scout", mutation="x"))
     assert not (gclaw_home / "children" / "early").exists()
@@ -60,6 +74,7 @@ def test_goodwill_is_irrelevant_proven_edge_gates(metabolism_fixture, gclaw_home
     _meta(metabolism_fixture, goodwill=8)
     _seed_dna(gclaw_home)
     _seed_forge(gclaw_home, proven=2)
+    monkeypatch.setattr(evolve, "_live_proven_ids", _live_from_style(gclaw_home))
     evolve.cmd_replicate(Namespace(auto=True, name=None, role=None, mutation=None))
     state = json.loads((gclaw_home / "metabolism.json").read_text(encoding="utf-8"))
     assert len(state["children"]) == 1
@@ -75,6 +90,7 @@ def test_dry_run_is_the_default_and_spawns_nothing(metabolism_fixture, gclaw_hom
     _meta(metabolism_fixture, goodwill=8)
     _seed_dna(gclaw_home)
     _seed_forge(gclaw_home, proven=2)
+    monkeypatch.setattr(evolve, "_live_proven_ids", _live_from_style(gclaw_home))
     evolve.cmd_replicate(Namespace(auto=True, name=None, role=None, mutation=None))
     assert not (gclaw_home / "children").exists()  # gate met, but nothing spawned
     state = json.loads((gclaw_home / "metabolism.json").read_text(encoding="utf-8"))
@@ -86,6 +102,7 @@ def test_anti_storm_requires_new_proven_edge(metabolism_fixture, gclaw_home, mon
     _meta(metabolism_fixture, goodwill=8)
     _seed_dna(gclaw_home)
     _seed_forge(gclaw_home, proven=2)
+    monkeypatch.setattr(evolve, "_live_proven_ids", _live_from_style(gclaw_home))
     evolve.cmd_replicate(Namespace(auto=True, name=None, role=None, mutation=None))
     # a second spawn with NO new proven edge (still 2) is refused
     with pytest.raises(SystemExit, match="no new proven edge"):
@@ -110,6 +127,7 @@ def test_partial_failure_rolls_back_the_child_dir(metabolism_fixture, gclaw_home
     _meta(metabolism_fixture, goodwill=8)
     _seed_dna(gclaw_home)
     _seed_forge(gclaw_home, proven=2)
+    monkeypatch.setattr(evolve, "_live_proven_ids", _live_from_style(gclaw_home))
     monkeypatch.setattr(
         evolve, "save_state", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("disk full"))
     )

--- a/tests/test_reputation.py
+++ b/tests/test_reputation.py
@@ -13,7 +13,12 @@ import reputation
 AID = "55624"
 
 
-def _seed(home: Path, adopted: list[dict], authored: list[str]) -> None:
+def _seed(
+    home: Path,
+    adopted: list[dict],
+    authored: list[str],
+    backtest_proven: tuple[str, ...] = (),
+) -> None:
     (home / "metabolism.json").write_text(
         json.dumps(
             {
@@ -34,14 +39,21 @@ def _seed(home: Path, adopted: list[dict], authored: list[str]) -> None:
     techs = home / "forge" / "techniques"
     techs.mkdir(parents=True, exist_ok=True)
     (home / "forge" / "style.json").write_text(json.dumps({"adopted": adopted}), encoding="utf-8")
-    for tid in authored:
+    for tid in {e["id"] for e in adopted} | set(authored):
         (techs / tid).mkdir(parents=True, exist_ok=True)
         (techs / tid / "technique.json").write_text(
-            json.dumps({"id": tid, "author": AID}), encoding="utf-8"
+            json.dumps(
+                {
+                    "id": tid,
+                    "author": AID if tid in authored else "other",
+                    "status": "proven" if tid in backtest_proven else "draft",
+                }
+            ),
+            encoding="utf-8",
         )
 
 
-def test_card_is_backed_by_settled_performance(gclaw_home, monkeypatch):
+def test_card_separates_live_proven_from_backtest_proven(gclaw_home, monkeypatch):
     monkeypatch.setattr(
         reputation,
         "_economics",
@@ -54,20 +66,37 @@ def test_card_is_backed_by_settled_performance(gclaw_home, monkeypatch):
             "expectancy": -0.77,
         },
     )
+    # The honest signal: only stop-hunt-revert has a REAL live edge (bootstrap CI > 0).
+    # vol-momentum merely graduated a backtest; its loose EWMA looks positive but the
+    # settled record does not clear the live gate — it must NOT count as proven edge.
+    monkeypatch.setattr(
+        reputation,
+        "_live_techniques",
+        lambda: {
+            "stop-hunt-revert": {"live_proven": True},
+            "vol-momentum": {"live_proven": False},
+            "weak": {"live_proven": False},
+        },
+    )
     _seed(
         gclaw_home,
         adopted=[
-            {"id": "stop-hunt-revert", "e": 0.16, "trades": 9},  # proven (seed author)
-            {"id": "vol-momentum", "e": 0.05, "trades": 5},  # proven + self-authored
-            {"id": "weak", "e": -0.01, "trades": 8},  # adopted but not proven
+            {"id": "stop-hunt-revert", "e": 0.16, "trades": 9},
+            {"id": "vol-momentum", "e": 0.05, "trades": 5},
+            {"id": "weak", "e": -0.01, "trades": 8},
         ],
         authored=["vol-momentum"],  # only this one is author==AID
+        backtest_proven=("stop-hunt-revert", "vol-momentum"),
     )
     c = reputation.card()
     assert c["agentId"] == AID
     assert c["trading"]["realized_pnl_usd"] == -39.82 and c["trading"]["closed_trades"] == 52
-    assert c["evolution"]["proven_edge_techniques"] == ["stop-hunt-revert", "vol-momentum"]
-    assert c["evolution"]["proven_edge_count"] == 2
+    # Headline (attested onchain) counts ONLY live-proven edge.
+    assert c["evolution"]["proven_edge_techniques"] == ["stop-hunt-revert"]
+    assert c["evolution"]["proven_edge_count"] == 1
+    # Backtest tier is reported separately and does not inflate the headline.
+    assert set(c["evolution"]["backtest_proven_techniques"]) == {"stop-hunt-revert", "vol-momentum"}
+    assert c["evolution"]["backtest_proven_count"] == 2
     assert c["evolution"]["self_authored_techniques"] == 1  # only vol-momentum is authored by AID
     assert c["evolution"]["children"] == 1
     assert c["verifiable_via"]["registry"] == "0xReg"
@@ -76,8 +105,10 @@ def test_card_is_backed_by_settled_performance(gclaw_home, monkeypatch):
 
 def test_publish_writes_the_canonical_file(gclaw_home, monkeypatch):
     monkeypatch.setattr(reputation, "_economics", lambda: {"n": 3, "net": 1.5})
+    monkeypatch.setattr(reputation, "_live_techniques", dict)
     _seed(gclaw_home, adopted=[], authored=[])
     reputation.cmd_publish(Namespace())
     written = json.loads((gclaw_home / "reputation.json").read_text(encoding="utf-8"))
     assert written["trading"]["realized_pnl_usd"] == 1.5
     assert written["evolution"]["proven_edge_count"] == 0
+    assert written["evolution"]["backtest_proven_count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ dev = [
 dev = [
     { name = "hypothesis", specifier = "==6.155.6" },
     { name = "mutmut", specifier = "==3.6.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.1.1" },
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -296,9 +296,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

"Proven edge" was computed four separate times from `style.json`'s **EWMA fitness counter** (`e>0 & trades>=3`), which can read positive from recency alone while the settled record is a net loss. The reputation scorecard, the replication gate, the dashboard, and the leaderboard manifest all used it — so a technique with no statistically-real edge (`stop-hunt-revert`: 9 fitness ticks, zero regime-matched live edge) was badged proven, counted toward the **onchain reputation**, and could unlock child **replication**. Meanwhile the forge's own `edge_real` gate refused to trade those same techniques.

## Fix

Define **live-proven** once: `memory.py`'s bootstrap-CI `edge_real` (95% CI above zero over ≥3 settled closes) — the same non-fakeable signal the forge already trusts for sizing.

- **`memory.py`** — add a `techniques` subcommand: the single source of truth for per-technique live edge and the `live_proven` flag.
- **`reputation.py`** — `proven_edge_*` now counts only live-proven techniques (what the onchain attestation reads); add `backtest_proven_*` so backtest graduation stays visible without inflating the headline.
- **`evolve.py`** — the replication gate reads the same live signal; backtest-only edges no longer breed children.
- **`dashboard.py`** — helix, breed gate, and loadout table read the one live-proven set instead of recomputing loosely.
- **`stats.js`** — the leaderboard manifest and rank `score` mirror the scorecard.

## Effect on the live agent

- `proven_edge_count`: **2 → 0** (honest — nothing is live-proven yet)
- `backtest_proven_count`: **7** (transparent — graduated backtests, not confirmed live)
- Replication gate: **"met" → CLOSED** ("0/2 — graduate more live edge first")

## Also in this PR

- **Dependabot #29** — bump `pytest` `8.4.2 → 9.1.1` (fixes vulnerable tmpdir handling, patched in ≥9.0.3) and relock. Suite passes clean across the major-version jump.
- **Version flip** — `4.0.0 → 4.1.0` (minor: scorecard semantics changed + new `backtest_proven_*` fields).

## Tests

`ruff` clean across `scripts/` + `tests/`; full suite **333 passed, 0 failed** on both pytest 8.4.2 and 9.1.1. Updated `test_reputation`, `test_evolve`, and `test_dashboard` to assert the two-tier behavior, including a case proving backtest-proven ≠ live-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
