### PR TITLE
Honest R-multiple attribution from pending.json (v4.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the gclaw skill are documented here. The format is based 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2026-07-07
+
+### Fixed
+
+- **Honest R-multiple attribution.** `autosettle` read per-trade risk from `open_risk.json`,
+  which nothing writes anymore, so every trade's R-multiple fell back to a 1.5%-of-notional
+  estimate. It now reads the real `risk_usd` the forge records in `pending.json` on open.
+  This sharpens the regime-conditional memory expectancy — and therefore the bootstrap-CI
+  the (now significance-gated) JUDGE keys on. (assune-ir5)
+
 ## [4.3.0] - 2026-07-07
 
 Harness red-team release: the backtest JUDGE was certifying noise as edge, so the agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "private": true,
   "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not \u2014 scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {

--- a/scripts/autosettle.js
+++ b/scripts/autosettle.js
@@ -175,7 +175,10 @@ async function main() {
     settled = true;
     const closers = fresh.filter((x) => Number(x.closedPnl || 0) !== 0);
     const regimes = fetchRegimes([...new Set(closers.map((f) => f.coin))]);
-    const openRisk = readJson(path.join(GCLAW_HOME, 'open_risk.json'), {});
+    // Real per-trade risk lives in the forge's pending.json (written on open, keyed by
+    // coin: {ref, technique, regime, risk_usd}). open_risk.json was dead — nothing wrote
+    // it — so every R-multiple fell back to a 1.5%-of-notional ESTIMATE (assune-d39/ir5).
+    const pending = readJson(path.join(GCLAW_HOME, 'forge', 'pending.json'), {});
     // Auto-attribute each closing fill to its technique's author (royalty) AND
     // record the outcome to the trade-memory (technique x regime -> R) so the agent
     // learns which techniques actually work in which conditions.
@@ -188,13 +191,12 @@ async function main() {
         technique = JSON.parse(out.toString()).technique || '';
       } catch { /* attribution is best-effort */ }
       try {
-        // open_risk.json entry may be a bare risk number or {risk, technique} the
-        // agent labelled at entry. Fall back to "discretionary" (a learnable bucket).
-        const orec = openRisk[f.coin];
-        const labelled = orec && typeof orec === 'object' ? orec : { risk: orec };
+        const prec = pending[f.coin] || {};
         const notional = Math.abs(Number(f.sz || 0)) * Number(f.px || 0);
-        const risk = labelled.risk || notional * 0.015 || 0.25; // sized risk, else 1.5%-stop estimate
-        const tech = technique || labelled.technique || 'discretionary';
+        // Real sized risk from the forge; fall back to a 1.5%-stop estimate for a manual
+        // close with no pending record. Fall back to "discretionary" (a learnable bucket).
+        const risk = Number(prec.risk_usd) || notional * 0.015 || 0.25;
+        const tech = technique || prec.technique || 'discretionary';
         const side = String(f.dir || '').includes('Short') ? 'short' : 'long';
         // expectancy must be net of ALL fees (exchange + builder), not gross
         const netPnl = Number(f.closedPnl) - Number(f.fee || 0) - Number(f.builderFee || 0);


### PR DESCRIPTION
autosettle read per-trade risk from the dead open_risk.json, so every R-multiple was a 1.5%-of-notional estimate. Now reads the real risk_usd from pending.json — sharpening the memory CI the significance-gated JUDGE keys on. Closes assune-ir5 (Fix B; Fix A was already resolved by the sizing refactor). 310 node tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)