### PR TITLE
Backlog: breaker bad-read guard + log rotation (v4.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the gclaw skill are documented here. The format is based 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.2] - 2026-07-07
+
+### Fixed
+
+- **Circuit-breaker safety: riskguard now guards against a bad equity read.** The two
+  breaker implementations were meant to be identical, but riskguard.js lacked forge.py's
+  bad-read guard — a transient status read yielding equity 0 (with a prior high-water mark)
+  computed a 100% drawdown and flattened the *entire* book. A non-positive equity read is
+  now inert, matching forge. (assune-xde, safety part)
+
+### Changed
+
+- **Log rotation.** `heartbeat.log` and `predict_bot.log` are rotated at a size cap
+  (10 MiB, one prior generation) instead of growing unbounded. (assune-old)
+
 ## [4.3.1] - 2026-07-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "private": true,
   "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not \u2014 scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -1774,7 +1774,14 @@ MAX_OPEN_POSITIONS = 3  # cap concurrent positions to bound concentration
 
 
 def circuit_breaker(equity: float, n_positions: int) -> dict[str, Any]:
-    """Update the equity high-water mark and decide whether new entries are allowed."""
+    """Update the equity high-water mark and decide whether new entries are allowed.
+
+    Shares the SAME drawdown invariant as riskguard.js (which is the enforcer that
+    flattens the book on a trip): a bad equity read is inert, the HWM rise is 20%-capped
+    per read, and a trip fires at MAX_DRAWDOWN_PCT. The two must stay byte-identical on
+    these rules or one re-poisons what the other corrects (assune-xde) — riskguard.js was
+    missing the bad-read guard until it was added there.
+    """
     path = gclaw_home() / "breaker.json"
     state = {}
     try:

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -16,6 +16,17 @@ MODEL="${GCLAW_MODEL:-sonnet}"
 SKILL_DIR="${GCLAW_SKILL_DIR:-$HOME/.claude/skills/gclaw}"
 mkdir -p "$GCLAW_HOME"
 
+# Size-based log rotation (assune-old): heartbeat.log and predict_bot.log are append-only
+# and were never rotated. Roll to a single prior generation when past the cap, checked once
+# per run. Done here (hourly, deterministic) rather than in the 2-min predict cron, so no
+# writer holds an fd on the file being rotated.
+MAX_LOG_BYTES="${GCLAW_MAX_LOG_BYTES:-10485760}" # 10 MiB
+for _lf in "$LOG" "$GCLAW_HOME/predict_bot.log"; do
+  if [[ -f "$_lf" && "$(stat -c%s "$_lf" 2>/dev/null || echo 0)" -gt "$MAX_LOG_BYTES" ]]; then
+    mv -f "$_lf" "$_lf.1" 2>/dev/null || true
+  fi
+done
+
 # cron has a minimal PATH; ensure node + user bins resolve. Adjust if needed.
 NODE_DIR="$(command -v node 2>/dev/null || true)"; NODE_DIR="${NODE_DIR%/node}"
 # cron's bare env has no nvm on PATH, so fall back to the newest nvm node bin.

--- a/scripts/riskguard.js
+++ b/scripts/riskguard.js
@@ -110,6 +110,10 @@ function breakerCheck(eq, positions, dry) {
   // both write this same file, so if the logic differs one re-poisons what the other
   // corrected (the un-capped Math.max here silently undid forge's fix every heartbeat).
   const prevHwm = Number(prev.hwm) || 0;
+  // A bad/zero equity read must NEVER trip the breaker: eq=0 computes a 100% drawdown and
+  // would flatten the entire book on a transient read failure. forge.py guards this via its
+  // "no equity read" skip; mirror it here (this file is the enforcer that actually flattens).
+  if (!(eq > 0)) return { hwm: prevHwm, drawdown: 0, tripped: false, skipped: 'no equity read' };
   const hwm = prevHwm > 0 ? Math.max(prevHwm, Math.min(eq, prevHwm * 1.20)) : eq;
   const drawdown = hwm > 0 ? (hwm - eq) / hwm : 0;
   const tripped = drawdown >= dd;

--- a/tests/node/riskguard.test.js
+++ b/tests/node/riskguard.test.js
@@ -199,6 +199,17 @@ describe('drawdown breaker', () => {
     expect(drawdown).toBe(0);
   });
 
+  // The dangerous case (assune-xde): a bad (0) equity read WITH a prior high-water mark.
+  // The old code computed (hwm-0)/hwm = 100% drawdown and flattened the entire book on a
+  // transient read failure. The bad-read guard keeps it inert, matching forge.py.
+  test('breakerCheck does not trip on a bad (0) equity read even with a prior hwm', () => {
+    const rg = loadWith(statusResponder(makeStatus(0, [])));
+    fs.writeFileSync(path.join(tmpHome, 'breaker.json'), JSON.stringify({ hwm: 1000 }));
+    const { tripped, drawdown } = rg.breakerCheck(0, [], true);
+    expect(tripped).toBe(false);
+    expect(drawdown).toBe(0);
+  });
+
   // REGRESSION: a single transient high equity read (e.g. a double-counted balance)
   // must NOT poison the high-water mark and trip a false drawdown halt next read —
   // the un-capped Math.max here used to re-poison what forge.py's 20%-cap corrected,


### PR DESCRIPTION
Two backlog fixes.

- **assune-xde (safety part):** riskguard.js lacked forge.py's bad-read guard, so a transient equity=0 read with a prior high-water mark computed 100% drawdown and flattened the whole book. Added the guard + regression test. The pure single-writer convergence remains as noted lower-risk cleanup.
- **assune-old:** rotate heartbeat.log / predict_bot.log at a 10 MiB cap.

riskguard 77 node tests + forge invariants green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)