### PR TITLE
Harness grader + proven-pair revalidation + metabolism fix (v4.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the gclaw skill are documented here. The format is based 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] - 2026-07-07
+
+### Added
+
+- **Harness grader** (`evals/harness_grade.py`) — one honest letter grade for the whole
+  harness, synthesizing the evals + live state. Severity is a hard floor, not a weight: a
+  broken JUDGE / cost model / feature caps the grade outright, and missing data
+  (a skipped eval, event calibration n=0) scores UNGRADED/STALE and caps the ceiling —
+  never a default pass. Every run appends to `harness_grades.jsonl` for trend/regression.
+  Each eval gained an additive `--json` line (run.py output unchanged). First live grade: B.
+- **`forge.py revalidate`** — re-runs every registered proven pair through the current gate
+  and drops the ones that no longer clear it. Run once: 36 of 37 pairs were noise certified
+  under the old gate; only 1 survived.
+- **Multiple-comparisons cap** (`AUTOPROVE_MAX_PER_TECH`) — bounds the proven pairs a
+  technique may hold to its strongest few by edge_score, so it can't sprawl across a dozen
+  markets on look-elsewhere luck.
+
+### Fixed
+
+- **Metabolism froze.** `metabolism.py tick` (the GMAC heartbeat burn) was only ever called
+  from the interactive `/gclaw` skill, never the cron, so the unattended agent's survival
+  accounting silently stopped. It now runs deterministically each heartbeat.
+
 ## [4.3.2] - 2026-07-07
 
 ### Fixed

--- a/evals/README.md
+++ b/evals/README.md
@@ -13,6 +13,28 @@ uv run --no-project python3 evals/judge_power.py    # or run one directly
 
 Each eval exits `0` on PASS, non-zero on FAIL.
 
+## The harness grader
+
+`harness_grade.py` sits **on top** of the evals and produces one honest, letter-graded
+report card of the whole harness — synthesizing the evals plus live state, weighing
+severity instead of averaging it.
+
+```bash
+uv run --no-project python3 evals/harness_grade.py           # full grade
+uv run --no-project python3 evals/harness_grade.py --quick   # skip judge_power (caps at F/STALE)
+uv run --no-project python3 evals/harness_grade.py --json     # machine-readable, appended to history
+uv run --no-project python3 evals/harness_grade.py --fail-under B   # nonzero exit below B (CI gate)
+```
+
+Its one load-bearing rule: **severity is a hard floor, not a weight.** A broken JUDGE, a
+live-money-leaking cost model, or a corrupted feature *caps* the letter grade outright, so
+unrelated green checks can never launder a systemically broken harness into a pass. Missing
+data (a skipped eval, event calibration with `n=0`) scores UNGRADED/STALE and caps the
+ceiling — never a default pass. Every run appends to `~/.gclaw/harness_grades.jsonl` for the
+trend/regression layer (a floor dimension flipping PASS→FAIL fires a REGRESSION banner).
+
+v1 is fully deterministic. The LLM decision-quality dimension is v2 (tracked: `assune-tx0.3`).
+
 | eval | question it answers | guards |
 |------|---------------------|--------|
 | `judge_power` | Does the backtest JUDGE certify signals with **no real edge**? Feeds structured signals through the real `_backtest_with` gate on block-bootstrapped **surrogate** data and measures the noise-certification rate. | JUDGE significance gate |

--- a/evals/cost_truth.py
+++ b/evals/cost_truth.py
@@ -104,6 +104,12 @@ def main() -> int:
 
     verdict = "PASS" if modeled_rt >= true_rt - TOL else "FAIL"
     print(f"\nVERDICT: {verdict}  (forge models {modeled_rt*1e4:.1f}bp vs true {true_rt*1e4:.1f}bp)")
+    if "--json" in sys.argv:
+        print(json.dumps({
+            "eval": "cost_truth", "modeled_bp": modeled_rt * 1e4, "true_bp": true_rt * 1e4,
+            "gap_bp": gap * 1e4, "builder_share": r["builder_rate"] / r["true_side"],
+            "flipped": len(c["flipped"]), "fragile": len(c["fragile"]), "verdict": verdict,
+        }))
     return 0 if modeled_rt >= true_rt - TOL else 1
 
 

--- a/evals/feature_parity.py
+++ b/evals/feature_parity.py
@@ -101,6 +101,11 @@ def main() -> int:
         ok = ok and mismatches[k] == 0
     print(f"\nVERDICT: {'PASS' if ok else 'FAIL'}  (backtest features "
           f"{'match' if ok else 'DIVERGE from'} the live definition)")
+    if "--json" in sys.argv:
+        print(json.dumps({
+            "eval": "feature_parity", "worst": worst,
+            "total_mismatches": sum(mismatches.values()), "verdict": "PASS" if ok else "FAIL",
+        }))
     return 0 if ok else 1
 
 

--- a/evals/harness_grade.py
+++ b/evals/harness_grade.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""harness_grade — a thoughtful graded report card for the whole gclaw harness.
+
+The point-evals (judge_power, cost_truth, feature_parity, tool_budget) each answer ONE
+yes/no question. This grader sits on top and produces a single, honest assessment of the
+harness as a whole. Its one load-bearing design choice: **severity is enforced as hard
+floors, not weighted averaging** — a broken JUDGE, a live-money-leaking cost model, or a
+corrupted feature caps the letter grade outright, so unrelated green checks can never
+launder a systemically broken harness into a passing grade.
+
+Two-pass grade:
+  Pass 1  weighted score over the graded dimensions -> provisional letter.
+  Pass 2  apply floor caps + calibration ceiling + regression cap (each only lowers),
+          take the strictest.
+
+Missing data (a skipped eval, event calibration with n=0) scores UNGRADED/STALE and caps
+the ceiling — it is never defaulted to a pass, because in this harness the check you didn't
+run is exactly what produced 37 false "proven" pairs the first time.
+
+v1 is fully deterministic. The LLM decision-quality dimension is v2 (assune-tx0.3).
+
+  uv run --no-project python3 evals/harness_grade.py            # full grade
+  uv run --no-project python3 evals/harness_grade.py --quick    # skip the slow judge_power
+  uv run --no-project python3 evals/harness_grade.py --json      # machine-readable record
+Exit: 0 unless --fail-under LETTER is set and the grade is below it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import forge  # noqa: E402  (for gclaw_home() — same env resolution the evals use)
+
+HOME = forge.gclaw_home()
+HISTORY = HOME / "harness_grades.jsonl"
+POINTS = {"A": 4, "B": 3, "C": 2, "D": 1, "F": 0}
+LETTERS = [(90, "A"), (80, "B"), (65, "C"), (50, "D"), (0, "F")]
+# Score ceilings imposed by a binding cap (a cap only ever lowers the grade).
+CAP_SCORE = {"F": 30, "D": 50, "C": 65, "Bplus": 88}
+
+
+def letter_of(score: float) -> str:
+    for floor, letter in LETTERS:
+        if score >= floor:
+            return letter
+    return "F"
+
+
+def _read_json(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return default
+
+
+def run_eval(module: str, quick: bool) -> dict[str, Any] | None:
+    """Run one eval with --json and return its final machine-readable line, or None.
+
+    None means the eval did not produce a verdict this run (skipped or crashed) — the
+    caller scores that as STALE/F, never a silent pass.
+    """
+    if quick and module == "judge_power":
+        return None
+    proc = subprocess.run(
+        [sys.executable, str(HERE / f"{module}.py"), "--json"],
+        capture_output=True, text=True, check=False,
+    )
+    for line in reversed(proc.stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except ValueError:
+                return None
+    return None
+
+
+# ── Dimension scorers: each returns a dict describing one graded dimension ──────
+
+
+def _dim(name: str, weight: int, grade: str, why: str, number: str, *, floor: bool = False,
+         override: bool = False) -> dict[str, Any]:
+    return {
+        "name": name, "weight": weight, "grade": grade, "why": why, "number": number,
+        "floor": floor, "override": override,
+        "points": POINTS.get(grade),  # None for UNGRADED/STALE — excluded from the blend
+    }
+
+
+def score_judge(jp: dict[str, Any] | None) -> dict[str, Any]:
+    if jp is None:
+        return _dim("JUDGE Statistical Power", 20, "STALE",
+                    "judge_power not run this invocation (--quick) — a skipped gate is not a pass",
+                    "not run", floor=True)
+    fpr, target = jp["fpr"], jp["target"]
+    grade = "A" if fpr <= target * 0.5 else "B" if fpr <= target else "F"
+    return _dim("JUDGE Statistical Power", 20, grade,
+                "gate certifies surrogate noise below the alpha target" if grade != "F"
+                else "gate certifies structureless noise as edge",
+                f"surrogate-FPR {fpr:.1%} vs <= {target:.1%}", floor=True)
+
+
+def score_cost(ct: dict[str, Any] | None) -> dict[str, Any]:
+    if ct is None:
+        return _dim("Cost-Model Fidelity", 15, "STALE", "cost_truth produced no verdict", "n/a",
+                    floor=True)
+    gap = ct["gap_bp"]
+    grade = "A" if ct["verdict"] == "PASS" else "C" if gap <= 3 else "F"
+    return _dim("Cost-Model Fidelity", 15, grade,
+                "JUDGE models the true venue cost" if grade == "A"
+                else "JUDGE understates the true round-trip cost — edges are subsidised",
+                f"modeled {ct['modeled_bp']:.1f}bp vs true {ct['true_bp']:.1f}bp", floor=True)
+
+
+def score_parity(fp: dict[str, Any] | None) -> dict[str, Any]:
+    if fp is None:
+        return _dim("Train/Serve Feature Parity", 15, "STALE", "feature_parity produced no verdict",
+                    "n/a", floor=True)
+    mism = fp["total_mismatches"]
+    grade = "A" if mism == 0 else "C" if mism <= 2 else "F"
+    return _dim("Train/Serve Feature Parity", 15, grade,
+                "backtest features match the live definition" if grade == "A"
+                else "backtest reconstructs features differently from live — silent train/serve skew",
+                f"{mism} feature/bar mismatches", floor=True)
+
+
+def score_mc(live: dict[str, Any]) -> dict[str, Any]:
+    cap_wired = "AUTOPROVE_MAX_PER_TECH" in (SCRIPTS / "forge.py").read_text(encoding="utf-8")
+    pairs = live["proven_markets"].get("pairs", [])
+    per_tech = {}
+    for p in pairs:
+        per_tech[p["technique"]] = per_tech.get(p["technique"], 0) + 1
+    max_sprawl = max(per_tech.values()) if per_tech else 0
+    snap = live.get("proven_markets_prev")
+    drop = ""
+    if snap is not None:
+        before = len(snap.get("pairs", []))
+        if before:
+            drop = f"; last revalidate dropped {before - len(pairs)}/{before}"
+    if not cap_wired:
+        grade = "D"
+    elif max_sprawl <= 3:
+        grade = "A"
+    else:
+        grade = "C"  # cap wired but a technique still sprawls (pre-cap residue)
+    return _dim("Multiple-Comparisons Discipline", 10, grade,
+                "per-technique cap wired; no technique sprawls across markets" if grade == "A"
+                else "look-elsewhere control weak — a technique spans many markets" if grade == "C"
+                else "no multiple-comparisons cap wired in autoprove",
+                f"{len(pairs)} proven pairs, max {max_sprawl}/technique{drop}")
+
+
+def score_live(live: dict[str, Any]) -> dict[str, Any]:
+    rep = live["reputation"].get("trading", {})
+    brk = live["breaker"]
+    exp = float(rep.get("expectancy_usd", 0) or 0)
+    dd = float(brk.get("drawdown_pct", 0) or 0)
+    if brk.get("tripped"):
+        grade, why = "F", "circuit breaker tripped — book flattened on drawdown"
+    elif exp > 0:
+        grade, why = "B", "positive live expectancy per closed trade"
+    elif dd < 15:
+        grade, why = "C", "negative expectancy but drawdown contained; no live-proven edge yet"
+    else:
+        grade, why = "D", "negative expectancy and a material drawdown"
+    return _dim("Live Decision Quality", 15, grade, why,
+                f"expectancy ${exp:.2f}, win {float(rep.get('win_rate', 0) or 0):.0%}, "
+                f"drawdown {dd:.1f}%", override=bool(brk.get("tripped")))
+
+
+def score_calibration(live: dict[str, Any]) -> dict[str, Any]:
+    cal = live["reputation"].get("event_calibration", {})
+    n = int(cal.get("n", 0) or 0)
+    if n == 0:
+        return _dim("Event-Desk Calibration", 5, "UNGRADED",
+                    "no resolved outcome tickets yet — Brier is uncomputable (caps ceiling at B+)",
+                    "n=0 resolved")
+    brier, base = cal.get("brier"), cal.get("no_skill_baseline")
+    grade = "A" if brier is not None and base is not None and brier < base else "F"
+    return _dim("Event-Desk Calibration", 5, grade,
+                "resolved Brier beats the no-skill baseline" if grade == "A"
+                else "resolved Brier no better than a no-skill guesser",
+                f"n={n}, brier={brier}")
+
+
+def score_edge(live: dict[str, Any]) -> dict[str, Any]:
+    ev = live["reputation"].get("evolution", {})
+    proven = int(ev.get("proven_edge_count", 0) or 0)
+    backtest = int(ev.get("backtest_proven_count", 0) or 0)
+    if proven > 0:
+        grade, why = "A", f"{proven} technique(s) show a live bootstrap-CI-positive edge"
+    elif backtest > 0:
+        grade, why = "C", ("0 live-proven of "
+                           f"{backtest} backtest-proven — correct for a strict gate in a hard "
+                           "market OR a broken execution path; statistics alone can't tell")
+    else:
+        grade, why = "C", "no proven techniques either way"
+    return _dim("Edge Realness", 5, grade, why, f"{proven} live / {backtest} backtest proven")
+
+
+def score_hygiene(tb: dict[str, Any] | None) -> dict[str, Any]:
+    if tb is None:
+        return _dim("Operational Hygiene", 5, "STALE", "tool_budget produced no verdict", "n/a")
+    if tb["critical_fails"]:
+        grade, why = "C", "a read tool leaks context / lacks structured errors"
+    elif tb["warns"]:
+        grade, why = "B", "read tools economical; minor warnings"
+    else:
+        grade, why = "A", "MCP read surface is context-economical"
+    return _dim("Operational Hygiene", 5, grade, why,
+                f"{tb['critical_fails']} critical, {tb['warns']} warn")
+
+
+# ── Aggregation: two-pass, floors dominate the arithmetic ──────────────────────
+
+
+def aggregate(dims: list[dict[str, Any]], prev: dict[str, Any] | None) -> dict[str, Any]:
+    graded = [d for d in dims if d["points"] is not None]
+    wsum = sum(d["weight"] for d in graded)
+    prov_score = (sum(d["weight"] * d["points"] for d in graded) / wsum / 4 * 100) if wsum else 0.0
+
+    caps: list[tuple[int, str]] = []
+    for d in dims:
+        if d["floor"] and d["grade"] in ("F", "STALE"):
+            tier = "F" if d["name"].startswith("JUDGE") else "D" if "Cost" in d["name"] else "C"
+            caps.append((CAP_SCORE[tier], f"{d['name']} = {d['grade']} (floor)"))
+    if any(d["name"].startswith("Event-Desk") and d["grade"] == "UNGRADED" for d in dims):
+        caps.append((CAP_SCORE["Bplus"], "event calibration UNGRADED"))
+
+    regression = None
+    if prev:
+        for d in dims:
+            if not d["floor"]:
+                continue
+            pg = next((x for x in prev.get("dimensions", []) if x["name"] == d["name"]), None)
+            if pg and POINTS.get(pg.get("grade")) not in (None, 0) and d["grade"] in ("F", "STALE"):
+                regression = f"{d['name']} regressed {pg['grade']} -> {d['grade']}"
+                caps.append((CAP_SCORE["D"], "regression on a floor dimension"))
+
+    final_score = min([prov_score] + [c[0] for c in caps])
+    binding = min(caps, key=lambda c: c[0])[1] if caps and min(c[0] for c in caps) < prov_score else ""
+    return {
+        "provisional_score": round(prov_score, 1),
+        "provisional_letter": letter_of(prov_score),
+        "score": round(final_score, 1),
+        "letter": letter_of(final_score),
+        "capped_by": binding,
+        "regression": regression,
+    }
+
+
+def top_risks(dims: list[dict[str, Any]], live: dict[str, Any]) -> list[dict[str, Any]]:
+    ranked = []
+    for d in dims:
+        pts = d["points"] if d["points"] is not None else 0  # UNGRADED counts as risk
+        sev = d["weight"] * (4 - pts)
+        if d["override"] or (d["floor"] and d["grade"] in ("F", "STALE")):
+            sev += 1000  # a tripped breaker / broken floor always claims the top
+        if sev > 0:
+            ranked.append({"name": d["name"], "grade": d["grade"], "why": d["why"], "sev": sev})
+    ranked.sort(key=lambda r: r["sev"], reverse=True)
+    return ranked[:3]
+
+
+# ── Live state + history ───────────────────────────────────────────────────────
+
+
+def load_live() -> dict[str, Any]:
+    fdir = HOME / "forge"
+    snaps = sorted(fdir.glob("proven_markets.json.pre-revalidate-*"), key=lambda p: p.stat().st_mtime)
+    return {
+        "reputation": _read_json(HOME / "reputation.json", {}),
+        "breaker": _read_json(HOME / "breaker.json", {}),
+        "metabolism": _read_json(HOME / "metabolism.json", {}),
+        "proven_markets": _read_json(fdir / "proven_markets.json", {"pairs": []}),
+        "proven_markets_prev": _read_json(snaps[-1], None) if snaps else None,
+    }
+
+
+def load_last() -> dict[str, Any] | None:
+    if not HISTORY.exists():
+        return None
+    for ln in reversed([x for x in HISTORY.read_text(encoding="utf-8").splitlines() if x.strip()]):
+        try:
+            return json.loads(ln)
+        except ValueError:
+            continue
+    return None
+
+
+def append_history(record: dict[str, Any]) -> None:
+    HISTORY.parent.mkdir(parents=True, exist_ok=True)
+    with HISTORY.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def _arrow(dim: dict[str, Any], prev: dict[str, Any] | None) -> str:
+    if not prev:
+        return " "
+    pg = next((x for x in prev.get("dimensions", []) if x["name"] == dim["name"]), None)
+    if not pg or dim["points"] is None or POINTS.get(pg.get("grade")) is None:
+        return " "
+    delta = dim["points"] - POINTS[pg["grade"]]
+    return "^" if delta > 0 else "v" if delta < 0 else "="
+
+
+# ── Render ─────────────────────────────────────────────────────────────────────
+
+
+def render_text(dims: list[dict[str, Any]], agg: dict[str, Any], risks: list[dict[str, Any]],
+                live: dict[str, Any], prev: dict[str, Any], fresh: int, total: int) -> None:
+    rep = live["reputation"].get("trading", {})
+    print("=" * 72)
+    print(f"  gclaw HARNESS GRADE:  {agg['letter']}    (score {agg['score']:.0f}/100)")
+    if agg["capped_by"]:
+        print(f"  not higher because:  {agg['capped_by']}  "
+              f"(uncapped would be {agg['provisional_letter']}/{agg['provisional_score']:.0f})")
+    if agg["regression"]:
+        print(f"  ** REGRESSION DETECTED: {agg['regression']} **")
+    print(f"  {fresh}/{total} evals ran fresh this invocation")
+    print("=" * 72)
+    print(f"  {'dimension':<32}{'grade':>6}{'':>3}{'detail':<28}")
+    print("  " + "-" * 68)
+    for d in dims:
+        floor = " (floor)" if d["floor"] else ""
+        print(f"  {d['name'][:31]:<32}{d['grade']:>6}{_arrow(d, prev):>3}  {d['number'][:26]:<26}{floor}")
+    print("  " + "-" * 68)
+    print(f"  live KPIs:  expectancy ${float(rep.get('expectancy_usd', 0) or 0):.2f}   "
+          f"win {float(rep.get('win_rate', 0) or 0):.0%}   "
+          f"realized ${float(rep.get('realized_pnl_usd', 0) or 0):.2f}   "
+          f"drawdown {float(live['breaker'].get('drawdown_pct', 0) or 0):.1f}%")
+    print("\n  TOP RISKS (severity-ranked, independent of the letter):")
+    for i, r in enumerate(risks, 1):
+        print(f"   {i}. [{r['grade']}] {r['name']} — {r['why']}")
+    if risks:
+        print(f"\n  FIX FIRST:  {risks[0]['name']} — {risks[0]['why']}")
+    print()
+
+
+def main() -> int:
+    quick = "--quick" in sys.argv
+    as_json = "--json" in sys.argv
+    modules = ("judge_power", "cost_truth", "feature_parity", "tool_budget")
+    evals = {m: run_eval(m, quick) for m in modules}
+    fresh = sum(1 for v in evals.values() if v is not None)
+    live = load_live()
+    prev = load_last()
+    dims = [
+        score_judge(evals["judge_power"]), score_cost(evals["cost_truth"]),
+        score_parity(evals["feature_parity"]), score_mc(live), score_live(live),
+        score_calibration(live), score_edge(live), score_hygiene(evals["tool_budget"]),
+    ]
+    agg = aggregate(dims, prev)
+    risks = top_risks(dims, live)
+    rep = live["reputation"].get("trading", {})
+    record = {
+        "grade": agg["letter"], "score": agg["score"], "provisional": agg["provisional_score"],
+        "capped_by": agg["capped_by"], "regression": agg["regression"],
+        "dimensions": [{"name": d["name"], "grade": d["grade"], "number": d["number"]} for d in dims],
+        "kpis": {k: rep.get(k) for k in ("expectancy_usd", "win_rate", "realized_pnl_usd")},
+        "fresh_evals": fresh, "git_sha": _git_sha(),
+    }
+    append_history(record)
+    if as_json:
+        print(json.dumps(record))
+    else:
+        render_text(dims, agg, risks, live, prev, fresh, len(modules))
+    if "--fail-under" in sys.argv:
+        want = sys.argv[sys.argv.index("--fail-under") + 1].upper()
+        if POINTS.get(agg["letter"], 0) < POINTS.get(want, 0):
+            return 1
+    return 0
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.run(["git", "-C", str(SCRIPTS.parent), "rev-parse", "--short", "HEAD"],
+                              capture_output=True, text=True, check=False).stdout.strip()
+    except OSError:
+        return ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/judge_power.py
+++ b/evals/judge_power.py
@@ -172,6 +172,8 @@ def main() -> int:
     print(f"P(a null signal is 'proven' on >=1 coin) = 1-(1-{fpr:.3f})^30 = {mc:.0%}.")
     verdict = "PASS" if fpr <= FPR_TARGET else "FAIL"
     print(f"\nVERDICT: {verdict}  (surrogate-FPR {fpr:.1%} vs target <={FPR_TARGET:.1%})")
+    if "--json" in sys.argv:  # additive: a final machine-readable line for the harness grader
+        print(json.dumps({"eval": "judge_power", "fpr": fpr, "target": FPR_TARGET, "verdict": verdict}))
     return 0 if fpr <= FPR_TARGET else 1
 
 

--- a/evals/tool_budget.py
+++ b/evals/tool_budget.py
@@ -106,6 +106,11 @@ def main() -> int:
         print(f"\nremaining (non-critical): {', '.join(f'{r['tool']} — {r['check']}' for r in warns)}")
     verdict = "PASS" if not critical_fail else "FAIL"
     print(f"\nVERDICT: {verdict}  ({len(critical_fail)} critical hygiene failures)")
+    if "--json" in sys.argv:
+        print(json.dumps({
+            "eval": "tool_budget", "critical_fails": len(critical_fail), "warns": len(warns),
+            "saved_tokens": emp.get("saved_tokens", 0), "verdict": verdict,
+        }))
     return 0 if not critical_fail else 1
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "private": true,
   "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not \u2014 scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -1065,6 +1065,32 @@ PROVEN_MARKETS_FILE = "proven_markets.json"
 AUTOPROVE_BUDGET = 6  # backtests per heartbeat — bounded cost
 AUTOPROVE_COOLDOWN_H = 12.0  # don't re-attempt a failing (technique, coin) for this long
 AUTOPROVE_LIMIT = 1000  # candles per backtest (matches `prove`)
+# Multiple-comparisons control: even with the per-test significance gate, sweeping ONE
+# technique across the whole universe still "proves" on some coins by look-elsewhere luck
+# (family-wise 1-(1-alpha)^C over C coins — the residual in judge_power's 28% line). Cap the
+# proven pairs a technique may hold to its strongest few by edge_score, so it can't sprawl
+# across a dozen markets on noise (trend-pullback was registered on 13 coins).
+AUTOPROVE_MAX_PER_TECH = int(os.environ.get("GCLAW_AUTOPROVE_MAX_PER_TECH") or 3)
+
+
+def _cap_proven_pairs(pairs: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
+    """Keep at most ``cap`` proven pairs per technique — the strongest by edge_score.
+
+    edge_score (expectancy x sqrt(oos_n)) is the same confidence-weighted rank the fitness
+    loop uses, so the cap keeps a technique's best-evidenced markets and drops the
+    look-elsewhere tail.
+    """
+    by_tech: dict[str, list[dict[str, Any]]] = {}
+    for p in pairs:
+        by_tech.setdefault(p["technique"], []).append(p)
+    kept: list[dict[str, Any]] = []
+    for tech_pairs in by_tech.values():
+        tech_pairs.sort(
+            key=lambda p: float(p.get("expectancy", 0)) * math.sqrt(max(1, int(p.get("oos_n", 0)))),
+            reverse=True,
+        )
+        kept.extend(tech_pairs[:cap])
+    return kept
 
 
 def _proven_markets_path() -> Path:
@@ -1144,9 +1170,58 @@ def cmd_autoprove(args: argparse.Namespace) -> dict[str, Any]:
             )
             proved.append(f"{tid}@{coin}")
     reg["attempts"] = attempts
+    reg["pairs"] = _cap_proven_pairs(reg["pairs"], AUTOPROVE_MAX_PER_TECH)
     _proven_markets_path().parent.mkdir(parents=True, exist_ok=True)
     _proven_markets_path().write_text(json.dumps(reg, indent=2) + "\n", encoding="utf-8")
     return {"ok": True, "tried": tried, "newly_proven": proved, "proven_markets": len(reg["pairs"])}
+
+
+def cmd_revalidate(_args: argparse.Namespace) -> dict[str, Any]:
+    """Re-run every registered proven pair through the CURRENT gate and drop the ones that
+    no longer clear it, then apply the per-technique cap.
+
+    A one-time cleanup after tightening the JUDGE: the existing pairs were certified under
+    the old significance-free gate (positive OOS mean only), so many are look-elsewhere
+    noise that the bootstrap-CI gate now rejects.
+    """
+    reg = load_proven_markets()
+    original = reg.get("pairs", [])
+    survivors: list[dict[str, Any]] = []
+    dropped_by_gate: list[dict[str, str]] = []
+    for p in original:
+        tid, coin, interval = p["technique"], p["coin"], p.get("interval", "1h")
+        try:
+            card = _backtest_with(load_signal(tid), coin, interval, AUTOPROVE_LIMIT, tid)
+        except (ValueError, OSError, KeyError):
+            dropped_by_gate.append({"technique": tid, "coin": coin, "reason": "thin/bad data"})
+            continue
+        if card.get("proven"):
+            survivors.append(
+                {
+                    "technique": tid,
+                    "coin": coin,
+                    "interval": interval,
+                    "oos_n": card["out_of_sample"]["n"],
+                    "expectancy": round(card["out_of_sample"]["expectancy"], 6),
+                    "at": now_iso(),
+                }
+            )
+        else:
+            dropped_by_gate.append(
+                {"technique": tid, "coin": coin, "reason": "fails significance gate"}
+            )
+    capped = _cap_proven_pairs(survivors, AUTOPROVE_MAX_PER_TECH)
+    reg["pairs"] = capped
+    _proven_markets_path().parent.mkdir(parents=True, exist_ok=True)
+    _proven_markets_path().write_text(json.dumps(reg, indent=2) + "\n", encoding="utf-8")
+    return {
+        "ok": True,
+        "before": len(original),
+        "survived_gate": len(survivors),
+        "after_cap": len(capped),
+        "dropped_by_gate": len(dropped_by_gate),
+        "dropped_by_cap": len(survivors) - len(capped),
+    }
 
 
 def cmd_list(_args: argparse.Namespace) -> dict[str, Any]:
@@ -2502,6 +2577,9 @@ def build_parser() -> argparse.ArgumentParser:
     ap = sub.add_parser("autoprove", help="backtest the arsenal across the liquid universe")
     ap.add_argument("--budget", type=int, default=None, help="max backtests this run")
     ap.set_defaults(fn=cmd_autoprove)
+    sub.add_parser(
+        "revalidate", help="re-run registered proven pairs through the current gate; drop failures"
+    ).set_defaults(fn=cmd_revalidate)
 
     au = sub.add_parser(
         "author", help="propose a signal body; validate+backtest+adopt-if-proven (never executes)"

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -67,6 +67,14 @@ Hard rules: you may NOT open a discretionary trade (no hl_perp.js open, no MCP p
 echo "===== $(ts) heartbeat start (model=$MODEL) =====" >>"$LOG"
 cd "$HOME"
 
+# Metabolism: charge one heartbeat — the living-agent burn (GMAC decrements each cycle,
+# the survival clock the whole organism runs on). tick was only ever called from the
+# interactive /gclaw skill (SKILL.md), never the cron, so the unattended agent's GMAC
+# accounting silently froze. Run it here, deterministically, every cycle. The burn does
+# NOT force unprofitable trading (audit assune-d39 ruled that out) — it just keeps the
+# survival economics honest. Hibernate mode self-skips the charge.
+[[ -f "$SKILL_DIR/scripts/metabolism.py" ]] &&
+  echo "$(ts) metabolism: $(uv run --no-project python3 "$SKILL_DIR/scripts/metabolism.py" tick 2>&1 | tr '\n' ' ' | tail -c 160)" >>"$LOG" || true
 # Auto-fund: convert any ETH sent to Arbitrum into USDC + deposit to HL.
 [[ -f "$SKILL_DIR/scripts/autofund.js" ]] &&
   echo "$(ts) autofund: $(node "$SKILL_DIR/scripts/autofund.js" run 2>&1)" >>"$LOG" || true

--- a/tests/test_harness_grade.py
+++ b/tests/test_harness_grade.py
@@ -1,0 +1,83 @@
+"""Tests for the harness grader — the invariant that matters is anti-gaming: a broken
+FLOOR dimension must cap the overall grade regardless of how green everything else is,
+so unrelated passing checks can never launder a systemically broken harness into a pass.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+EVALS = Path(__file__).resolve().parent.parent / "evals"
+if str(EVALS) not in sys.path:
+    sys.path.insert(0, str(EVALS))
+
+import harness_grade as hg  # noqa: E402
+
+
+def test_letter_thresholds() -> None:
+    assert hg.letter_of(95) == "A"
+    assert hg.letter_of(80) == "B"
+    assert hg.letter_of(65) == "C"
+    assert hg.letter_of(50) == "D"
+    assert hg.letter_of(49.9) == "F"
+
+
+def test_judge_scorer_grades() -> None:
+    assert hg.score_judge({"fpr": 0.02, "target": 0.075})["grade"] == "A"  # well under
+    assert hg.score_judge({"fpr": 0.06, "target": 0.075})["grade"] == "B"  # under
+    assert hg.score_judge({"fpr": 0.30, "target": 0.075})["grade"] == "F"  # certifies noise
+    assert hg.score_judge(None)["grade"] == "STALE"  # skipped is never a pass
+    assert hg.score_judge(None)["floor"] is True
+
+
+def _all_A_except(broken: dict) -> list[dict]:
+    """A dimension set that is all A except the one broken floor dim passed in."""
+    dims = [
+        hg._dim("Cost-Model Fidelity", 15, "A", "", "", floor=True),
+        hg._dim("Train/Serve Feature Parity", 15, "A", "", "", floor=True),
+        hg._dim("Multiple-Comparisons Discipline", 10, "A", "", ""),
+        hg._dim("Live Decision Quality", 15, "A", "", ""),
+        hg._dim("Edge Realness", 5, "A", "", ""),
+        hg._dim("Operational Hygiene", 5, "A", "", ""),
+    ]
+    return [broken, *dims]
+
+
+def test_broken_judge_caps_grade_at_F_despite_all_else_A() -> None:
+    # The anti-gaming core: JUDGE = F (certifies noise) with everything else A.
+    dims = _all_A_except(hg._dim("JUDGE Statistical Power", 20, "F", "", "", floor=True))
+    agg = hg.aggregate(dims, None)
+    # Averaging alone would NOT fail it — the 20%-weighted F only pulls the blend to a
+    # non-failing C. The floor cap is what correctly forces F; that gap is the whole point.
+    assert hg.POINTS[agg["provisional_letter"]] >= hg.POINTS["C"]
+    assert agg["letter"] == "F"  # the floor cap dominates the arithmetic
+    assert "JUDGE" in agg["capped_by"]
+
+
+def test_skipped_judge_also_caps() -> None:
+    dims = _all_A_except(hg._dim("JUDGE Statistical Power", 20, "STALE", "", "", floor=True))
+    assert hg.aggregate(dims, None)["letter"] == "F"
+
+
+def test_broken_cost_caps_at_D() -> None:
+    dims = _all_A_except(hg._dim("JUDGE Statistical Power", 20, "A", "", "", floor=True))
+    dims = [d if "Cost" not in d["name"] else hg._dim("Cost-Model Fidelity", 15, "F", "", "", floor=True)
+            for d in dims]
+    agg = hg.aggregate(dims, None)
+    assert agg["letter"] == "D"  # cost floor caps at D, not F
+
+
+def test_ungraded_calibration_caps_ceiling_and_is_excluded() -> None:
+    dims = _all_A_except(hg._dim("JUDGE Statistical Power", 20, "A", "", "", floor=True))
+    dims.append(hg._dim("Event-Desk Calibration", 5, "UNGRADED", "", ""))
+    agg = hg.aggregate(dims, None)
+    assert agg["provisional_score"] == 100.0  # UNGRADED excluded from the blend, not scored 0
+    assert agg["letter"] == "B"  # ceiling-capped at B+ (88)
+
+
+def test_regression_on_floor_dim_fires_banner_and_caps() -> None:
+    prev = {"dimensions": [{"name": "JUDGE Statistical Power", "grade": "A"}]}
+    dims = _all_A_except(hg._dim("JUDGE Statistical Power", 20, "F", "", "", floor=True))
+    agg = hg.aggregate(dims, prev)
+    assert agg["regression"] is not None and "JUDGE" in agg["regression"]


### PR DESCRIPTION
## Added
- **Harness grader** (evals/harness_grade.py) — one honest letter grade for the whole harness. Severity is a hard floor, not a weight: a broken JUDGE/cost/feature caps the grade outright; missing data scores UNGRADED/STALE and caps the ceiling, never a default pass. Trend/regression via harness_grades.jsonl. First live grade: **B** (mechanics all A; capped by ungraded calibration + no live-proven edge yet). Designed by a 4-lens agent team + synthesis; 7 tests pin the anti-gaming floor-cap invariant. Each eval gained an additive `--json` line (run.py unchanged).
- **forge.py revalidate** — re-runs registered proven pairs through the current gate, drops failures. Ran once: **36 of 37 were noise** certified under the old gate; 1 survived.
- **Multiple-comparisons cap** (AUTOPROVE_MAX_PER_TECH) — bounds proven pairs per technique so no technique sprawls across markets on look-elsewhere luck.

## Fixed
- **Metabolism froze** — `metabolism.py tick` was only called from the interactive skill, never the cron, so the unattended agent's GMAC accounting stopped. Now runs each heartbeat.

Tests: grader 7, forge regression 70, node/vitest 310 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)