### PR TITLE
Fix heartbeat pipefail regression in per-cycle archiving (v4.5.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,6 @@ assets/generated/*-ticker*.png
 assets/generated/dashboard-preview.html
 
 # eval data fixtures — real fills (personal) + regenerable candle blobs; not source
-evals/fixtures/
+evals/fixtures/*
+# ...but the decision-quality monotonicity fixtures ARE source (committed, hand-written)
+!evals/fixtures/dq_*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the gclaw skill are documented here. The format is based 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.1] - 2026-07-07
+
+### Fixed
+
+- **Regression in v4.5.0's per-cycle archiving.** The prune step (`ls *.report.txt | tail`)
+  exited non-zero when no archives existed yet, and under the heartbeat's `set -euo pipefail`
+  that killed the whole heartbeat before the LLM cycle ran — so active cycles skipped their
+  LLM run *and* the post-cycle riskguard/dashboard. compgen-guarded and failure-swallowed.
+
 ## [4.5.0] - 2026-07-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "private": true,
   "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not \u2014 scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -210,10 +210,15 @@ else
   CYCLE_BASE="$CYCLE_DIR/$(ts | tr -d ':')"
   printf '%s' "$BRIEF" >"$CYCLE_BASE.brief.txt" 2>/dev/null || true
   REPORT_FILE="$CYCLE_BASE.report.txt"
-  # shellcheck disable=SC2012  # ls -t ordering is what we want; filenames are our own ts-based
-  ls -1t "$CYCLE_DIR"/*.report.txt 2>/dev/null | tail -n +241 | while read -r _old; do
-    rm -f "$_old" "${_old%.report.txt}.brief.txt" 2>/dev/null || true
-  done
+  # Prune to the most recent 240 cycles. MUST be pipefail/set -e safe: with no matches the
+  # glob is literal and ls exits non-zero, which under `set -euo pipefail` would kill the
+  # whole heartbeat before the LLM cycle even runs. compgen-guard it and swallow any failure.
+  if compgen -G "$CYCLE_DIR/*.report.txt" >/dev/null 2>&1; then
+    # shellcheck disable=SC2012  # ls -t ordering is what we want; filenames are our own ts-based
+    ls -1t "$CYCLE_DIR"/*.report.txt 2>/dev/null | tail -n +241 | while read -r _old; do
+      rm -f "$_old" "${_old%.report.txt}.brief.txt" 2>/dev/null || true
+    done || true
+  fi
   if printf '%s' "$FULL_PROMPT" | timeout "$CYCLE_TIMEOUT" claude --print --permission-mode bypassPermissions \
       --model "$MODEL" --disallowedTools $DENY >"$REPORT_FILE" 2>&1; then
     cat "$REPORT_FILE" >>"$LOG"


### PR DESCRIPTION
v4.5.0's per-cycle prune killed the heartbeat under `set -euo pipefail` when no archives existed yet, so active cycles skipped their LLM run + post-cycle riskguard/dashboard. compgen-guarded + failure-swallowed; verified the empty-dir case survives. Deployed synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)