### PR TITLE
Fix dex-blind order read flattening xyz positions as naked (v4.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the gclaw skill are documented here. The format is based 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.0] - 2026-07-08
+
+### Fixed
+
+- **xyz builder-dex positions were flattened as "naked" though their stop was resting all
+  along** (assune-ehh). riskguard reads open orders via `hl_perp.js` status, which called the
+  HL `openOrders` endpoint with no `dex` — so it only ever saw the **main dex**. A protective
+  stop resting on the xyz builder dex was invisible, so every xyz position read as naked and
+  riskguard flattened it on sight for a guaranteed loss. The order read now queries `openOrders`
+  **per-dex** (main + each builder dex) and merges, mirroring how positions are already read.
+  Verified live: a test xyz:BB open's SL/TP rest on the xyz dex and are now seen; riskguard
+  computes real risk (0.2%), no flatten. The "attached SL isn't armed resting on xyz" comments
+  were a misdiagnosis of this dex-blind read and are corrected.
+
+### Changed
+
+- **xyz origination enabled** (`GCLAW_ALLOW_XYZ_OPEN=1`). With the naked-flatten fixed, the
+  forge can trade builder markets again — unblocking the one revalidation-surviving proven pair,
+  `deviation-revert / xyz:BB`. The toggle is kept as a kill-switch for the thin builder book.
+
 ## [4.5.1] - 2026-07-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gclaw-skill-tests",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "private": true,
   "description": "Dev/test tooling for the Gclaw skill's node scripts. The scripts are CommonJS and depend on ethers + the GDEX SDK resolved from ~/gdex-skill at runtime. vitest + ethers are installed here (predict.js's tested keccak path needs ethers); the GDEX SDK is not \u2014 scripts that need it load it tolerantly and their tested functions are pure.",
   "scripts": {

--- a/references/2026-07-fee-wall-and-gate-fix.md
+++ b/references/2026-07-fee-wall-and-gate-fix.md
@@ -86,9 +86,10 @@ maker (~1.5bp), so the round trip the edge must beat is ~3bp, not ~15bp.
   with the stop STILL atomically attached — a single `hl_create_order` action carrying
   `price + tpPrice + slPrice + isMarket`, so the entry is NEVER naked — and the backtest
   charges maker entry. One env var flips both, so the cost model can never diverge from
-  the fill. Builder (`xyz:`) coins always stay taker: their attached SL is not armed as a
-  resting order (assune-ehh), so a resting entry there would fill naked; the executor
-  gates maker off for them.
+  the fill. Builder (`xyz:`) coins always stay taker: whether a resting maker-limit entry's
+  SL arms on that dex at async fill is unverified, so the executor gates maker off for them.
+  (Their market opens DO arm a resting SL — verified live; the earlier "naked xyz" was a
+  dex-blind order read, assune-ehh, since fixed.)
 - **Scientist prompt biased toward the right setups** (`dna/HEARTBEAT.md` §4b): author
   FEWER, BIGGER, higher-conviction setups that fire rarely and hold long enough that the
   move dwarfs the round trip — not high-frequency scalps that die to fees.

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -120,8 +120,9 @@ BUILDER_FEE = 0.0005  # builder fee per side (both entry and exit)
 # posts a resting maker limit with the stop STILL atomically attached (one hl_create_order
 # action, never naked) on the default dex, and the backtest charges maker entry. The single
 # env var keeps the cost assumption from ever diverging from how fills actually happen.
-# Builder (xyz) coins always stay taker: their attached SL is not armed as a resting order
-# (assune-ehh), so a resting entry there would fill naked — hl_perp.js gates maker off for them.
+# Builder (xyz) coins always stay taker: whether a resting maker-limit entry's SL arms on
+# that dex at async fill is unverified — hl_perp.js gates maker off for them. (Their market
+# opens DO arm a resting SL; that path is verified — the old "naked xyz" was a dex-blind read.)
 def _maker_entry() -> bool:
     """True when entries are modelled as resting maker limits (assune-4yt), else taker."""
     return os.environ.get("GCLAW_FORGE_MAKER_ENTRY") == "1"
@@ -2338,10 +2339,11 @@ def _gate_intents(
     for i in intents:
         if not (i["proven"] and i["notional"] >= MIN_NOTIONAL):
             continue
-        # xyz builder-dex opens land NAKED — managed custody does not arm the attached
-        # SL trigger as a resting order there, so riskguard flattens them on sight for a
-        # guaranteed loss (assune-opy). Gate xyz out of auto-origination until that SL
-        # attachment is verified; flip GCLAW_ALLOW_XYZ_OPEN=1 once it is fixed.
+        # xyz builder-dex opens used to be flattened on sight as "naked" — but the stop was
+        # there all along, resting on the xyz dex; riskguard just read open orders on the
+        # main dex only and never saw it (assune-ehh, fixed in hl_perp.js allOpenOrders,
+        # verified live). GCLAW_ALLOW_XYZ_OPEN stays as a kill-switch for the thin builder
+        # book; default-on. When off, xyz intents are skipped.
         if ":" in i["coin"] and not allow_xyz:
             continue
         if i["confidence"] < conv_floor:

--- a/scripts/hl_perp.js
+++ b/scripts/hl_perp.js
@@ -22,7 +22,8 @@
  *
  * Entry fill type follows GCLAW_FORGE_MAKER_ENTRY (assune-4yt): unset → taker market
  * (default); =1 → resting maker limit with the stop atomically attached, on the default
- * dex only (builder xyz: coins stay taker — their attached SL is not armed resting).
+ * dex only (builder xyz: coins stay taker — resting-limit SL arming on that dex is untested;
+ * their market opens DO arm a resting SL, verified).
  */
 'use strict';
 
@@ -133,6 +134,21 @@ async function builderDexes(skill) {
   return [...set];
 }
 
+// Open orders across default AND every builder dex. The HL `openOrders` endpoint (and the
+// SDK's getHlOpenOrders that wraps it) defaults to the MAIN dex — it takes an optional `dex`
+// param but the SDK never passes one. So a protective stop resting on the xyz builder dex is
+// INVISIBLE, which made riskguard read every xyz position as NAKED and flatten it on sight
+// (assune-ehh — the stop was there all along, just on a dex nobody queried). Query each dex
+// explicitly and merge, exactly like fullState does for positions.
+async function allOpenOrders(skill, managed) {
+  const dexes = await builderDexes(skill).catch(() => []);
+  const results = await Promise.all([
+    hlInfo({ type: 'openOrders', user: managed }),
+    ...dexes.map((dex) => hlInfo({ type: 'openOrders', user: managed, dex })),
+  ]);
+  return results.flatMap((r) => (Array.isArray(r) ? r : []));
+}
+
 // True equity + positions across default AND every builder dex. Builder/HIP-3
 // positions (xyz:NVDA, …) live under their own dex, not `default`. The bundled
 // "…StateAll" endpoint is stale (omits xyz), so query each dex explicitly via the
@@ -190,9 +206,10 @@ function roundSig(value, sig = 5) {
 
 // Maker-entry mode (assune-4yt): when GCLAW_FORGE_MAKER_ENTRY=1 the forge models the
 // entry as a resting maker limit, so the live executor must POST one too or the cost
-// model diverges from reality. Only the default dex is eligible: on the xyz builder dex
-// the attached SL trigger is not armed as a resting order (assune-ehh), so a resting
-// entry there would fill naked — builder coins always stay taker.
+// model diverges from reality. Only the default dex is eligible: whether a resting maker
+// limit's attached SL arms on the xyz builder dex at async fill is unverified, so builder
+// coins always stay taker. (Their MARKET opens do arm a resting SL — that path is verified;
+// the earlier "naked xyz" was a dex-blind order read, assune-ehh, since fixed.)
 function makerEntryEnabled(coin) {
   return process.env.GCLAW_FORGE_MAKER_ENTRY === '1' && !coin.includes(':');
 }
@@ -277,7 +294,7 @@ async function cmdStatus(wallet) {
   const [fullR, spotR, ordersR] = await Promise.allSettled([
     fullState(skill, wallet.managed),
     skill.getHlSpotState(wallet.managed),
-    skill.getHlOpenOrders(wallet.managed),
+    allOpenOrders(skill, wallet.managed),
   ]);
   const full = fullR.status === 'fulfilled' ? fullR.value : { accountValue: 0, positions: [], withdrawable: 0 };
   const spot = spotR.status === 'fulfilled' ? spotR.value : { balances: [] };

--- a/tests/node/hl_perp.test.js
+++ b/tests/node/hl_perp.test.js
@@ -174,8 +174,8 @@ describe('coin normalization + sig rounding (entry-path helpers)', () => {
 // executor must POST a resting maker limit — with the stop STILL atomically attached —
 // so the executor matches the maker cost the forge backtest models. The order builder is
 // network-free, so we drive it directly and assert the maker/taker + no-naked-entry
-// contract. Builder (xyz) coins always stay taker: their attached SL is not armed as a
-// resting order (assune-ehh), so a resting entry there would fill naked.
+// contract. Builder (xyz) coins always stay taker: whether a resting maker-limit entry's SL
+// arms on that dex at async fill is unverified (their market opens DO arm a resting SL).
 describe('maker-first limit entries: order construction (assune-4yt)', () => {
   const { makerEntryEnabled, makerLimitPrice, buildOpenOrder } = loadScript('hl_perp.js');
   const savedFlag = process.env.GCLAW_FORGE_MAKER_ENTRY;
@@ -205,7 +205,7 @@ describe('maker-first limit entries: order construction (assune-4yt)', () => {
     expect(o.maker).toBe(true);
   });
 
-  test('flag on but builder (xyz) coin stays taker — its attached SL is not armed resting', () => {
+  test('flag on but builder (xyz) coin stays taker — resting-limit SL arming there unverified', () => {
     process.env.GCLAW_FORGE_MAKER_ENTRY = '1';
     expect(makerEntryEnabled('xyz:NVDA')).toBe(false);
     const o = buildOpenOrder({ coin: 'xyz:NVDA', isLong: true, mark: 120, notionalTarget: 30, slPct: 2, tpPct: 3, szDecimals: 2 });


### PR DESCRIPTION
**Root cause (assune-ehh):** riskguard reads open orders via `hl_perp.js` status, which called HL's `openOrders` endpoint with **no `dex`** — so it only saw the main dex. A stop resting on the xyz builder dex was invisible → every xyz position read as naked → riskguard flattened it for a guaranteed loss. The "SL isn't armed resting on xyz" comments were a misdiagnosis of this.

**Fix:** `allOpenOrders()` queries `openOrders` **per-dex** (main + each builder dex via the direct `hlInfo` helper) and merges — mirroring how `fullState` already reads positions per-dex. No SDK/backend change; no risk-model change.

**Verified live:** opened a minimal xyz:BB long — its SL (10.835) + TP (11.388) rest on the xyz dex and are now seen; riskguard computes real risk (0.2%), takes no action; closed the test. SOL (a concurrent real forge trade) reads correctly throughout.

**Enabled** `GCLAW_ALLOW_XYZ_OPEN=1` so the forge can trade the one revalidation-surviving proven pair, `deviation-revert/xyz:BB`. Toggle kept as a kill-switch.

Tests: 23 node + forge suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)